### PR TITLE
Bitstream: Removal of Redundant CType

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -22,6 +22,7 @@ on:
       - "**.c"
       - "**.h"
       - "windows/**"
+      - "src/rust/**"
 
 jobs:
   build_release:

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Fix: Segmentation faults on XDS files
 - Fix: Clippy Errors Based on Rust 1.88
 - IMPROVEMENT: Refactor and optimize Dockerfile
 - Fix: Improved handling of IETF language tags in Matroska files (#1665)

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Fix: Clippy Errors Based on Rust 1.88
 - IMPROVEMENT: Refactor and optimize Dockerfile
 - Fix: Improved handling of IETF language tags in Matroska files (#1665)
 - New: Create unit test for rust code (#1615)

--- a/src/lib_ccx/cc_bitstream.c
+++ b/src/lib_ccx/cc_bitstream.c
@@ -4,15 +4,15 @@
 // plus some data related helper functions.
 
 #ifndef DISABLE_RUST
-extern void* ccxr_init_bitstream(const uint8_t *start, const uint8_t *end);
+extern void *ccxr_init_bitstream(const uint8_t *start, const uint8_t *end);
 extern void ccxr_free_bitstream(void *bs);
 extern uint64_t ccxr_next_bits(void *bs, uint32_t bnum);
 extern uint64_t ccxr_read_bits(void *bs, uint32_t bnum);
 extern int ccxr_skip_bits(void *bs, uint32_t bnum);
 extern int ccxr_is_byte_aligned(const void *bs);
 extern void ccxr_make_byte_aligned(void *bs);
-extern const uint8_t* ccxr_next_bytes(void *bs, size_t bynum);
-extern const uint8_t* ccxr_read_bytes(void *bs, size_t bynum);
+extern const uint8_t *ccxr_next_bytes(void *bs, size_t bynum);
+extern const uint8_t *ccxr_read_bytes(void *bs, size_t bynum);
 extern uint64_t ccxr_read_exp_golomb_unsigned(void *bs);
 extern int64_t ccxr_read_exp_golomb(void *bs);
 extern uint8_t ccxr_reverse8(uint8_t data);

--- a/src/lib_ccx/cc_bitstream.c
+++ b/src/lib_ccx/cc_bitstream.c
@@ -4,17 +4,15 @@
 // plus some data related helper functions.
 
 #ifndef DISABLE_RUST
-extern void *ccxr_init_bitstream(const uint8_t *start, const uint8_t *end);
-extern void ccxr_free_bitstream(void *bs);
-extern uint64_t ccxr_next_bits(void *bs, uint32_t bnum);
-extern uint64_t ccxr_read_bits(void *bs, uint32_t bnum);
-extern int ccxr_skip_bits(void *bs, uint32_t bnum);
-extern int ccxr_is_byte_aligned(const void *bs);
-extern void ccxr_make_byte_aligned(void *bs);
-extern const uint8_t *ccxr_next_bytes(void *bs, size_t bynum);
-extern const uint8_t *ccxr_read_bytes(void *bs, size_t bynum);
-extern uint64_t ccxr_read_exp_golomb_unsigned(void *bs);
-extern int64_t ccxr_read_exp_golomb(void *bs);
+extern uint64_t ccxr_next_bits(struct bitstream bs, uint32_t bnum);
+extern uint64_t ccxr_read_bits(struct bitstream bs, uint32_t bnum);
+extern int ccxr_skip_bits(struct bitstream bs, uint32_t bnum);
+extern int ccxr_is_byte_aligned(struct bitstream bs);
+extern void ccxr_make_byte_aligned(struct bitstream bs);
+extern const uint8_t *ccxr_next_bytes(struct bitstream bs, size_t bynum);
+extern const uint8_t *ccxr_read_bytes(struct bitstream bs, size_t bynum);
+extern uint64_t ccxr_read_exp_golomb_unsigned(struct bitstream bs);
+extern int64_t ccxr_read_exp_golomb(struct bitstream bs);
 extern uint8_t ccxr_reverse8(uint8_t data);
 #endif
 
@@ -27,16 +25,6 @@ extern uint8_t ccxr_reverse8(uint8_t data);
 // Initialize bitstream
 int init_bitstream(struct bitstream *bstr, unsigned char *start, unsigned char *end)
 {
-#ifndef DISABLE_RUST
-	void *rust_bs = ccxr_init_bitstream(start, end);
-	if (!rust_bs)
-	{
-		mprint("init_bitstream: bitstream has negative length!");
-		return 1;
-	}
-	bstr->rust_bs = rust_bs;
-#endif
-
 	bstr->pos = start;
 	bstr->bpos = 8;
 	bstr->end = end;
@@ -61,7 +49,7 @@ int init_bitstream(struct bitstream *bstr, unsigned char *start, unsigned char *
 uint64_t next_bits(struct bitstream *bstr, unsigned bnum)
 {
 #ifndef DISABLE_RUST
-	return ccxr_next_bits(bstr->rust_bs, bnum);
+	return ccxr_next_bits(*bstr, bnum);
 #else
 	uint64_t res = 0;
 
@@ -135,7 +123,7 @@ uint64_t next_bits(struct bitstream *bstr, unsigned bnum)
 uint64_t read_bits(struct bitstream *bstr, unsigned bnum)
 {
 #ifndef DISABLE_RUST
-	return ccxr_read_bits(bstr->rust_bs, bnum);
+	return ccxr_read_bits(*bstr, bnum);
 #else
 	uint64_t res = next_bits(bstr, bnum);
 
@@ -158,7 +146,7 @@ uint64_t read_bits(struct bitstream *bstr, unsigned bnum)
 int skip_bits(struct bitstream *bstr, unsigned bnum)
 {
 #ifndef DISABLE_RUST
-	return ccxr_skip_bits(bstr->rust_bs, bnum);
+	return ccxr_skip_bits(*bstr, bnum);
 #else
 	// Sanity check
 	if (bstr->end - bstr->pos < 0)
@@ -198,7 +186,7 @@ int skip_bits(struct bitstream *bstr, unsigned bnum)
 int is_byte_aligned(struct bitstream *bstr)
 {
 #ifndef DISABLE_RUST
-	return ccxr_is_byte_aligned(bstr->rust_bs);
+	return ccxr_is_byte_aligned(*bstr);
 #else
 	// Sanity check
 	if (bstr->end - bstr->pos < 0)
@@ -222,7 +210,7 @@ int is_byte_aligned(struct bitstream *bstr)
 void make_byte_aligned(struct bitstream *bstr)
 {
 #ifndef DISABLE_RUST
-	ccxr_make_byte_aligned(bstr->rust_bs);
+	ccxr_make_byte_aligned(*bstr);
 #else
 	// Sanity check
 	if (bstr->end - bstr->pos < 0)
@@ -263,7 +251,7 @@ void make_byte_aligned(struct bitstream *bstr)
 unsigned char *next_bytes(struct bitstream *bstr, unsigned bynum)
 {
 #ifndef DISABLE_RUST
-	return (unsigned char *)ccxr_next_bytes(bstr->rust_bs, bynum);
+	return (unsigned char *)ccxr_next_bytes(*bstr, bynum);
 #else
 	// Sanity check
 	if (bstr->end - bstr->pos < 0)
@@ -297,7 +285,7 @@ unsigned char *next_bytes(struct bitstream *bstr, unsigned bynum)
 unsigned char *read_bytes(struct bitstream *bstr, unsigned bynum)
 {
 #ifndef DISABLE_RUST
-	return (unsigned char *)ccxr_read_bytes(bstr->rust_bs, bynum);
+	return (unsigned char *)ccxr_read_bytes(*bstr, bynum);
 #else
 	unsigned char *res = next_bytes(bstr, bynum);
 
@@ -355,7 +343,7 @@ uint64_t bitstream_get_num(struct bitstream *bstr, unsigned bytes, int advance)
 uint64_t read_exp_golomb_unsigned(struct bitstream *bstr)
 {
 #ifndef DISABLE_RUST
-	return ccxr_read_exp_golomb_unsigned(bstr->rust_bs);
+	return ccxr_read_exp_golomb_unsigned(*bstr);
 #else
 	uint64_t res = 0;
 	int zeros = 0;
@@ -373,7 +361,7 @@ uint64_t read_exp_golomb_unsigned(struct bitstream *bstr)
 int64_t read_exp_golomb(struct bitstream *bstr)
 {
 #ifndef DISABLE_RUST
-	return ccxr_read_exp_golomb(bstr->rust_bs);
+	return ccxr_read_exp_golomb(*bstr);
 #else
 	int64_t res = 0;
 

--- a/src/lib_ccx/cc_bitstream.h
+++ b/src/lib_ccx/cc_bitstream.h
@@ -1,7 +1,6 @@
 #ifndef _BITSTREAM_
 #define _BITSTREAM_
 
-
 // The structure holds the current position in the bitstream.
 // pos points to the current byte position and bpos counts the
 // bits left unread at the current byte pos. No bit read means
@@ -25,6 +24,9 @@ struct bitstream
 	// increased by the calling function, or not.
 	unsigned char *_i_pos;
 	int _i_bpos;
+#ifndef DISABLE_RUST
+	void *rust_bs;  // Pointer to Rust's Bitstream struct
+#endif
 };
 
 #define read_u8(bstream) (uint8_t)bitstream_get_num(bstream,1,1)

--- a/src/lib_ccx/cc_bitstream.h
+++ b/src/lib_ccx/cc_bitstream.h
@@ -24,9 +24,6 @@ struct bitstream
 	// increased by the calling function, or not.
 	unsigned char *_i_pos;
 	int _i_bpos;
-#ifndef DISABLE_RUST
-	void *rust_bs;  // Pointer to Rust's Bitstream struct
-#endif
 };
 
 #define read_u8(bstream) (uint8_t)bitstream_get_num(bstream,1,1)

--- a/src/lib_ccx/cc_bitstream.h
+++ b/src/lib_ccx/cc_bitstream.h
@@ -24,6 +24,9 @@ struct bitstream
 	// increased by the calling function, or not.
 	unsigned char *_i_pos;
 	int _i_bpos;
+#ifndef DISABLE_RUST
+	void *rust_bs;  // Pointer to Rust's Bitstream struct
+#endif
 };
 
 #define read_u8(bstream) (uint8_t)bitstream_get_num(bstream,1,1)

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -27,6 +27,7 @@ fn main() {
         ".*(?i)_?dtvcc_.*",
         "encoder_ctx",
         "lib_cc_decode",
+        "bitstream",
         "cc_subtitle",
         "ccx_output_format",
         "ccx_boundary_time",

--- a/src/rust/lib_ccxr/src/activity.rs
+++ b/src/rust/lib_ccxr/src/activity.rs
@@ -11,7 +11,7 @@ impl ActivityExt for Options {
         if self.gui_mode_reports {
             let mut stderr = io::stderr();
             let version = env!("CARGO_PKG_VERSION");
-            writeln!(stderr, "###VERSION#CCExtractor#{}", version).unwrap();
+            writeln!(stderr, "###VERSION#CCExtractor#{version}").unwrap();
             stderr.flush().unwrap();
         }
     }

--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -1,6 +1,25 @@
 use std::cmp::min;
 use thiserror::Error;
 
+/// Trait for converting Rust types to their C counterparts
+pub trait CType<T> {
+    /// Convert the Rust type to its C counterpart
+    ///
+    /// # Safety
+    /// This function is unsafe because it creates raw pointers and assumes the underlying data
+    /// remains valid for the lifetime of the C type. The caller must ensure that:
+    /// - The source data outlives the C type
+    /// - The pointers created are valid and properly aligned
+    /// - The data is not mutably aliased
+    unsafe fn to_ctype(&self) -> T;
+}
+
+/// Trait for converting C types to their Rust counterparts
+pub trait FromC<T> {
+    /// Convert the C type to its Rust counterpart
+    fn from_c(value: T) -> Self;
+}
+
 #[derive(Debug, Error)]
 pub enum BitstreamError {
     #[error("Bitstream has negative length")]
@@ -11,14 +30,62 @@ pub enum BitstreamError {
     TooManyBits(u32),
 }
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CCBitstream {
+    pub pos: *mut u8,
+    pub bpos: i32,
+    pub end: *mut u8,
+    pub bitsleft: i64,
+    pub error: i32,
+    pub _i_pos: *mut u8,
+    pub _i_bpos: i32,
+}
+
 pub struct Bitstream<'a> {
     pos: &'a [u8],
-    current_pos: usize,
     bpos: u8,
     bits_left: i64,
-    // Internal state for next_bits
+    error: i32,
     _i_pos: usize,
     _i_bpos: u8,
+}
+
+impl<'a> CType<CCBitstream> for Bitstream<'a> {
+    unsafe fn to_ctype(&self) -> CCBitstream {
+        CCBitstream {
+            pos: self.pos.as_ptr() as *mut u8,
+            bpos: self.bpos as i32,
+            end: self.pos.as_ptr().add(self.pos.len()) as *mut u8,
+            bitsleft: self.bits_left,
+            error: self.error,
+            _i_pos: self.pos.as_ptr().add(self._i_pos) as *mut u8,
+            _i_bpos: self._i_bpos as i32,
+        }
+    }
+}
+
+impl<'a> FromC<CCBitstream> for Bitstream<'a> {
+    fn from_c(value: CCBitstream) -> Self {
+        unsafe {
+            let len = value.end.offset_from(value.pos) as usize;
+            let slice = std::slice::from_raw_parts(value.pos, len);
+            let i_pos = if value._i_pos.is_null() {
+                0
+            } else {
+                value._i_pos.offset_from(value.pos) as usize
+            };
+
+            Bitstream {
+                pos: slice,
+                bpos: value.bpos as u8,
+                bits_left: value.bitsleft,
+                error: value.error,
+                _i_pos: i_pos,
+                _i_bpos: value._i_bpos as u8,
+            }
+        }
+    }
 }
 
 impl<'a> Bitstream<'a> {
@@ -29,9 +96,9 @@ impl<'a> Bitstream<'a> {
 
         Ok(Self {
             pos: data,
-            current_pos: 0,
             bpos: 8,
             bits_left: (data.len() as i64) * 8,
+            error: 0,
             _i_pos: 0,
             _i_bpos: 0,
         })
@@ -48,9 +115,8 @@ impl<'a> Bitstream<'a> {
         }
 
         // Calculate remaining bits
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
-            + self.bpos as i64
-            - bnum as i64;
+        self.bits_left =
+            (self.pos.len() as i64 - self._i_pos as i64 - 1) * 8 + self.bpos as i64 - bnum as i64;
         if self.bits_left < 0 {
             return Ok(0);
         }
@@ -60,7 +126,7 @@ impl<'a> Bitstream<'a> {
         }
 
         let mut vbit = self.bpos;
-        let mut vpos = self.current_pos;
+        let mut vpos = self._i_pos;
         let mut res = 0u64;
         let mut bits_to_read = bnum;
 
@@ -93,7 +159,6 @@ impl<'a> Bitstream<'a> {
             }
         }
 
-        // Remember position for potential read
         self._i_bpos = vbit;
         self._i_pos = vpos;
 
@@ -107,9 +172,7 @@ impl<'a> Bitstream<'a> {
             return Ok(0);
         }
 
-        // Advance the bitstream
         self.bpos = self._i_bpos;
-        self.current_pos = self._i_pos;
 
         Ok(res)
     }
@@ -120,9 +183,8 @@ impl<'a> Bitstream<'a> {
             return Ok(false);
         }
 
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
-            + self.bpos as i64
-            - bnum as i64;
+        self.bits_left =
+            (self.pos.len() as i64 - self._i_pos as i64 - 1) * 8 + self.bpos as i64 - bnum as i64;
         if self.bits_left < 0 {
             return Ok(false);
         }
@@ -132,7 +194,7 @@ impl<'a> Bitstream<'a> {
         }
 
         let mut new_bpos = (self.bpos as i32) - (bnum % 8) as i32;
-        let mut new_pos = self.current_pos + (bnum / 8) as usize;
+        let mut new_pos = self._i_pos + (bnum / 8) as usize;
 
         if new_bpos < 1 {
             new_bpos += 8;
@@ -140,7 +202,7 @@ impl<'a> Bitstream<'a> {
         }
 
         self.bpos = new_bpos as u8;
-        self.current_pos = new_pos;
+        self._i_pos = new_pos;
 
         Ok(true)
     }
@@ -166,11 +228,10 @@ impl<'a> Bitstream<'a> {
 
         if self.bpos != 8 {
             self.bpos = 8;
-            self.current_pos += 1;
+            self._i_pos += 1;
         }
 
-        self.bits_left =
-            (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64;
+        self.bits_left = (self.pos.len() as i64 - self._i_pos as i64 - 1) * 8 + self.bpos as i64;
         Ok(())
     }
 
@@ -180,8 +241,7 @@ impl<'a> Bitstream<'a> {
             return Ok(None);
         }
 
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
-            + self.bpos as i64
+        self.bits_left = (self.pos.len() as i64 - self._i_pos as i64 - 1) * 8 + self.bpos as i64
             - (bynum * 8) as i64;
 
         if !self.is_byte_aligned()? || self.bits_left < 0 || bynum < 1 {
@@ -189,10 +249,10 @@ impl<'a> Bitstream<'a> {
         }
 
         self._i_bpos = 8;
-        self._i_pos = self.current_pos + bynum;
+        self._i_pos += bynum;
 
         Ok(Some(
-            &self.pos[self.current_pos..min(self.current_pos + bynum, self.pos.len())],
+            &self.pos[self._i_pos..min(self._i_pos + bynum, self.pos.len())],
         ))
     }
 
@@ -206,18 +266,17 @@ impl<'a> Bitstream<'a> {
             return Ok(None);
         }
 
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
-            + self.bpos as i64
+        self.bits_left = (self.pos.len() as i64 - self._i_pos as i64 - 1) * 8 + self.bpos as i64
             - (bynum * 8) as i64;
         if self.bits_left < 0 {
             return Ok(None);
         }
 
-        let new_pos = self.current_pos + bynum;
-        let slice = &self.pos[self.current_pos..min(new_pos, self.pos.len())];
+        let new_pos = self._i_pos + bynum;
+        let slice = &self.pos[self._i_pos..min(new_pos, self.pos.len())];
 
         self.bpos = 8;
-        self.current_pos = new_pos;
+        self._i_pos = new_pos;
 
         Ok(Some(slice))
     }
@@ -248,135 +307,280 @@ impl<'a> Bitstream<'a> {
     }
 }
 
-// FFI exports
+/// Initialize a new bitstream from raw pointers
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences raw pointers
+/// - Creates a slice from raw parts
+/// - Assumes the memory between start and end is valid and properly aligned
+/// - Assumes the memory remains valid for the lifetime of the returned Bitstream
 #[no_mangle]
-pub extern "C" fn ccxr_init_bitstream(start: *const u8, end: *const u8) -> *mut Bitstream<'static> {
+pub unsafe extern "C" fn ccxr_init_bitstream(
+    start: *const u8,
+    end: *const u8,
+) -> *mut Bitstream<'static> {
     if start.is_null() || end.is_null() {
         return std::ptr::null_mut();
     }
 
-    unsafe {
-        let len = end.offset_from(start) as usize;
-        let slice = std::slice::from_raw_parts(start, len);
-        match Bitstream::new(slice) {
-            Ok(bs) => Box::into_raw(Box::new(bs)),
-            Err(_) => std::ptr::null_mut(),
-        }
+    let len = end.offset_from(start) as usize;
+    let slice = std::slice::from_raw_parts(start, len);
+    match Bitstream::new(slice) {
+        Ok(bs) => Box::into_raw(Box::new(bs)),
+        Err(_) => std::ptr::null_mut(),
     }
 }
 
+/// Free a bitstream created by ccxr_init_bitstream
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer
+/// - Assumes the pointer was created by ccxr_init_bitstream
+/// - Assumes no other references to the Bitstream exist
 #[no_mangle]
-pub extern "C" fn ccxr_free_bitstream(bs: *mut Bitstream<'static>) {
+pub unsafe extern "C" fn ccxr_free_bitstream(bs: *mut Bitstream<'static>) {
     if !bs.is_null() {
-        unsafe {
-            drop(Box::from_raw(bs));
+        drop(Box::from_raw(bs));
+    }
+}
+
+/// Read bits from a bitstream without advancing the position
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Modifies the bitstream state
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_next_bits(bs: *mut CCBitstream, bnum: u32) -> u64 {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    let val = match rust_bs.next_bits(bnum) {
+        Ok(val) => val,
+        Err(_) => return 0,
+    };
+    let updated_bs = unsafe { rust_bs.to_ctype() };
+    bs.pos = updated_bs.pos;
+    bs.bpos = updated_bs.bpos;
+    bs._i_pos = updated_bs._i_pos;
+    bs._i_bpos = updated_bs._i_bpos;
+    bs.bitsleft = updated_bs.bitsleft;
+    val
+}
+
+/// Read bits from a bitstream and advance the position
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Modifies the bitstream state
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_read_bits(bs: *mut CCBitstream, bnum: u32) -> u64 {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    let val = match rust_bs.read_bits(bnum) {
+        Ok(val) => val,
+        Err(_) => return 0,
+    };
+    let updated_bs = unsafe { rust_bs.to_ctype() };
+    bs.pos = updated_bs.pos;
+    bs.bpos = updated_bs.bpos;
+    bs._i_pos = updated_bs._i_pos;
+    bs._i_bpos = updated_bs._i_bpos;
+    bs.bitsleft = updated_bs.bitsleft;
+    val
+}
+
+/// Skip a number of bits in the bitstream
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Modifies the bitstream state
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_skip_bits(bs: *mut CCBitstream, bnum: u32) -> i32 {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    let val = match rust_bs.skip_bits(bnum) {
+        Ok(val) => val,
+        Err(_) => return 0,
+    };
+    let updated_bs = unsafe { rust_bs.to_ctype() };
+    bs.pos = updated_bs.pos;
+    bs.bpos = updated_bs.bpos;
+    bs._i_pos = updated_bs._i_pos;
+    bs._i_bpos = updated_bs._i_bpos;
+    bs.bitsleft = updated_bs.bitsleft;
+    if val {
+        1
+    } else {
+        0
+    }
+}
+
+/// Check if the bitstream is byte aligned
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_is_byte_aligned(bs: *const CCBitstream) -> i32 {
+    let bs = &*bs;
+    let rust_bs = Bitstream::from_c(*bs);
+    match rust_bs.is_byte_aligned() {
+        Ok(val) => {
+            if val {
+                1
+            } else {
+                0
+            }
         }
+        Err(_) => 0,
     }
 }
 
+/// Align the bitstream to the next byte boundary
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Modifies the bitstream state
 #[no_mangle]
-pub extern "C" fn ccxr_next_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 {
-    if bs.is_null() {
-        return 0;
+pub unsafe extern "C" fn ccxr_make_byte_aligned(bs: *mut CCBitstream) {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    if rust_bs.make_byte_aligned().is_ok() {
+        let updated_bs = unsafe { rust_bs.to_ctype() };
+        bs.pos = updated_bs.pos;
+        bs.bpos = updated_bs.bpos;
+        bs._i_pos = updated_bs._i_pos;
+        bs._i_bpos = updated_bs._i_bpos;
+        bs.bitsleft = updated_bs.bitsleft;
     }
-    unsafe { (*bs).next_bits(bnum).unwrap_or_default() }
 }
 
+/// Get a pointer to the next bytes in the bitstream without advancing
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Returns a raw pointer that must not outlive the bitstream
+/// - Modifies the bitstream state
 #[no_mangle]
-pub extern "C" fn ccxr_read_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 {
-    if bs.is_null() {
-        return 0;
-    }
-    unsafe { (*bs).read_bits(bnum).unwrap_or_default() }
+pub unsafe extern "C" fn ccxr_next_bytes(bs: *mut CCBitstream, bynum: usize) -> *const u8 {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    let bytes = match rust_bs.next_bytes(bynum) {
+        Ok(Some(bytes)) => bytes,
+        _ => return std::ptr::null(),
+    };
+    let bytes_ptr = bytes.as_ptr();
+    let updated_bs = unsafe { rust_bs.to_ctype() };
+    bs.pos = updated_bs.pos;
+    bs.bpos = updated_bs.bpos;
+    bs._i_pos = updated_bs._i_pos;
+    bs._i_bpos = updated_bs._i_bpos;
+    bs.bitsleft = updated_bs.bitsleft;
+    bytes_ptr
 }
 
+/// Read bytes from the bitstream and advance the position
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Returns a raw pointer that must not outlive the bitstream
+/// - Modifies the bitstream state
 #[no_mangle]
-pub extern "C" fn ccxr_skip_bits(bs: *mut Bitstream<'static>, bnum: u32) -> i32 {
-    if bs.is_null() {
-        return 0;
-    }
-    unsafe {
-        match (*bs).skip_bits(bnum) {
-            Ok(true) => 1,
-            Ok(false) => 0,
-            Err(_) => 0,
+pub unsafe extern "C" fn ccxr_read_bytes(bs: *mut CCBitstream, bynum: usize) -> *const u8 {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    let bytes = match rust_bs.read_bytes(bynum) {
+        Ok(Some(bytes)) => bytes,
+        _ => return std::ptr::null(),
+    };
+    let bytes_ptr = bytes.as_ptr();
+    let updated_bs = unsafe { rust_bs.to_ctype() };
+    bs.pos = updated_bs.pos;
+    bs.bpos = updated_bs.bpos;
+    bs._i_pos = updated_bs._i_pos;
+    bs._i_bpos = updated_bs._i_bpos;
+    bs.bitsleft = updated_bs.bitsleft;
+    bytes_ptr
+}
+
+/// Read an unsigned Exp-Golomb code from the bitstream
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Modifies the bitstream state
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_read_exp_golomb_unsigned(bs: *mut CCBitstream) -> u64 {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    match rust_bs.read_exp_golomb_unsigned() {
+        Ok(val) => {
+            let updated_bs = unsafe { rust_bs.to_ctype() };
+            bs.pos = updated_bs.pos;
+            bs.bpos = updated_bs.bpos;
+            bs._i_pos = updated_bs._i_pos;
+            bs._i_bpos = updated_bs._i_bpos;
+            bs.bitsleft = updated_bs.bitsleft;
+            val
         }
+        Err(_) => 0,
     }
 }
 
+/// Read a signed Exp-Golomb code from the bitstream
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer to CCBitstream
+/// - Assumes the pointer and contained data are valid and properly aligned
+/// - Modifies the bitstream state
 #[no_mangle]
-pub extern "C" fn ccxr_is_byte_aligned(bs: *const Bitstream<'static>) -> i32 {
-    if bs.is_null() {
-        return 0;
-    }
-    unsafe {
-        match (*bs).is_byte_aligned() {
-            Ok(true) => 1,
-            Ok(false) => 0,
-            Err(_) => 0,
+pub unsafe extern "C" fn ccxr_read_exp_golomb(bs: *mut CCBitstream) -> i64 {
+    let bs = &mut *bs;
+    let mut rust_bs = Bitstream::from_c(*bs);
+    match rust_bs.read_exp_golomb() {
+        Ok(val) => {
+            let updated_bs = unsafe { rust_bs.to_ctype() };
+            bs.pos = updated_bs.pos;
+            bs.bpos = updated_bs.bpos;
+            bs._i_pos = updated_bs._i_pos;
+            bs._i_bpos = updated_bs._i_bpos;
+            bs.bitsleft = updated_bs.bitsleft;
+            val
         }
+        Err(_) => 0,
     }
 }
 
+/// Reverse the bits in a byte
+///
+/// # Safety
+/// This function is unsafe because it is part of the FFI interface.
+/// However, it does not perform any unsafe operations internally.
 #[no_mangle]
-pub extern "C" fn ccxr_make_byte_aligned(bs: *mut Bitstream<'static>) {
-    if !bs.is_null() {
-        unsafe {
-            let _ = (*bs).make_byte_aligned();
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn ccxr_next_bytes(bs: *mut Bitstream<'static>, bynum: usize) -> *const u8 {
-    if bs.is_null() {
-        return std::ptr::null();
-    }
-    unsafe {
-        match (*bs).next_bytes(bynum) {
-            Ok(Some(bytes)) => bytes.as_ptr(),
-            _ => std::ptr::null(),
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn ccxr_read_bytes(bs: *mut Bitstream<'static>, bynum: usize) -> *const u8 {
-    if bs.is_null() {
-        return std::ptr::null();
-    }
-    unsafe {
-        match (*bs).read_bytes(bynum) {
-            Ok(Some(bytes)) => bytes.as_ptr(),
-            _ => std::ptr::null(),
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn ccxr_read_exp_golomb_unsigned(bs: *mut Bitstream<'static>) -> u64 {
-    if bs.is_null() {
-        return 0;
-    }
-    unsafe { (*bs).read_exp_golomb_unsigned().unwrap_or_default() }
-}
-
-#[no_mangle]
-pub extern "C" fn ccxr_read_exp_golomb(bs: *mut Bitstream<'static>) -> i64 {
-    if bs.is_null() {
-        return 0;
-    }
-    unsafe { (*bs).read_exp_golomb().unwrap_or_default() }
-}
-
-#[no_mangle]
-pub extern "C" fn ccxr_reverse8(data: u8) -> u8 {
+pub unsafe extern "C" fn ccxr_reverse8(data: u8) -> u8 {
     Bitstream::reverse8(data)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem;
 
     #[test]
     fn test_bitstream_creation() {
@@ -405,5 +609,118 @@ mod tests {
         assert!(!bs.is_byte_aligned().unwrap());
         bs.make_byte_aligned().unwrap();
         assert!(bs.is_byte_aligned().unwrap());
+    }
+
+    // FFI binding tests
+    #[test]
+    fn test_ffi_next_bits() {
+        let data = vec![0b10101010];
+        let mut c_bs = CCBitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(unsafe { ccxr_next_bits(&mut c_bs, 1) }, 1);
+    }
+
+    #[test]
+    fn test_ffi_read_bits() {
+        let data = vec![0b10101010];
+        let mut c_bs = CCBitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(unsafe { ccxr_read_bits(&mut c_bs, 3) }, 0b101);
+    }
+
+    #[test]
+    fn test_ffi_byte_alignment() {
+        let data = vec![0xFF];
+        let mut c_bs = CCBitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(unsafe { ccxr_is_byte_aligned(&c_bs) }, 1);
+        unsafe { ccxr_read_bits(&mut c_bs, 1) };
+        assert_eq!(unsafe { ccxr_is_byte_aligned(&c_bs) }, 0);
+    }
+
+    #[test]
+    fn test_ffi_read_bytes() {
+        static DATA: [u8; 3] = [0xAA, 0xBB, 0xCC];
+        let mut c_bs = CCBitstream {
+            pos: DATA.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { DATA.as_ptr().add(DATA.len()) } as *mut u8,
+            bitsleft: (DATA.len() as i64) * 8,
+            error: 0,
+            _i_pos: DATA.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        unsafe {
+            let ptr = ccxr_read_bytes(&mut c_bs, 2);
+            assert!(!ptr.is_null());
+            let b1 = *ptr;
+            let b2 = *ptr.add(1);
+            assert_eq!([b1, b2], [0xAA, 0xBB]);
+        }
+    }
+
+    #[test]
+    fn test_ffi_exp_golomb() {
+        let data = vec![0b10000000];
+        let data_ptr = data.as_ptr();
+        let mut c_bs = CCBitstream {
+            pos: data_ptr as *mut u8,
+            bpos: 8,
+            end: unsafe { data_ptr.add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data_ptr as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(unsafe { ccxr_read_exp_golomb_unsigned(&mut c_bs) }, 0);
+        mem::drop(data);
+    }
+
+    #[test]
+    fn test_ffi_reverse8() {
+        assert_eq!(unsafe { ccxr_reverse8(0b10101010) }, 0b01010101);
+    }
+
+    #[test]
+    fn test_ffi_state_updates() {
+        let data = vec![0xAA, 0xBB];
+        let mut c_bs = CCBitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        unsafe { ccxr_read_bits(&mut c_bs, 4) };
+        assert_eq!(c_bs.bpos, 4);
     }
 }

--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -1,0 +1,414 @@
+use std::cmp::min;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BitstreamError {
+    #[error("Bitstream has negative length")]
+    NegativeLength,
+    #[error("Illegal bit position value: {0}")]
+    IllegalBitPosition(u8),
+    #[error("Argument is greater than maximum bit number (64): {0}")]
+    TooManyBits(u32),
+}
+
+pub struct Bitstream<'a> {
+    pos: &'a [u8],
+    current_pos: usize,
+    bpos: u8,
+    bits_left: i64,
+    // Internal state for next_bits
+    _i_pos: usize,
+    _i_bpos: u8,
+}
+
+impl<'a> Bitstream<'a> {
+    pub fn new(data: &'a [u8]) -> Result<Self, BitstreamError> {
+        if data.is_empty() {
+            return Err(BitstreamError::NegativeLength);
+        }
+
+        Ok(Self {
+            pos: data,
+            current_pos: 0,
+            bpos: 8,
+            bits_left: (data.len() as i64) * 8,
+            _i_pos: 0,
+            _i_bpos: 0,
+        })
+    }
+
+    pub fn next_bits(&mut self, bnum: u32) -> Result<u64, BitstreamError> {
+        if bnum > 64 {
+            return Err(BitstreamError::TooManyBits(bnum));
+        }
+
+        if self.bits_left <= 0 {
+            self.bits_left -= bnum as i64;
+            return Ok(0);
+        }
+
+        // Calculate remaining bits
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - bnum as i64;
+        if self.bits_left < 0 {
+            return Ok(0);
+        }
+
+        if bnum == 0 {
+            return Ok(0);
+        }
+
+        let mut vbit = self.bpos;
+        let mut vpos = self.current_pos;
+        let mut res = 0u64;
+        let mut bits_to_read = bnum;
+
+        if vbit < 1 || vbit > 8 {
+            return Err(BitstreamError::IllegalBitPosition(vbit));
+        }
+
+        while bits_to_read > 0 {
+            if vpos >= self.pos.len() {
+                return Err(BitstreamError::NegativeLength);
+            }
+
+            let current_byte = self.pos[vpos];
+            res |= if (current_byte & (1 << (vbit - 1))) != 0 { 1 } else { 0 };
+            
+            vbit -= 1;
+            bits_to_read -= 1;
+
+            if vbit == 0 {
+                vpos += 1;
+                vbit = 8;
+            }
+
+            if bits_to_read > 0 {
+                res <<= 1;
+            }
+        }
+
+        // Remember position for potential read
+        self._i_bpos = vbit;
+        self._i_pos = vpos;
+
+        Ok(res)
+    }
+
+    pub fn read_bits(&mut self, bnum: u32) -> Result<u64, BitstreamError> {
+        let res = self.next_bits(bnum)?;
+
+        if bnum == 0 || self.bits_left < 0 {
+            return Ok(0);
+        }
+
+        // Advance the bitstream
+        self.bpos = self._i_bpos;
+        self.current_pos = self._i_pos;
+
+        Ok(res)
+    }
+
+    pub fn skip_bits(&mut self, bnum: u32) -> Result<bool, BitstreamError> {
+        if self.bits_left < 0 {
+            self.bits_left -= bnum as i64;
+            return Ok(false);
+        }
+
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - bnum as i64;
+        if self.bits_left < 0 {
+            return Ok(false);
+        }
+
+        if bnum == 0 {
+            return Ok(true);
+        }
+
+        let mut new_bpos = (self.bpos as i32) - (bnum % 8) as i32;
+        let mut new_pos = self.current_pos + (bnum / 8) as usize;
+
+        if new_bpos < 1 {
+            new_bpos += 8;
+            new_pos += 1;
+        }
+
+        self.bpos = new_bpos as u8;
+        self.current_pos = new_pos;
+
+        Ok(true)
+    }
+
+    pub fn is_byte_aligned(&self) -> Result<bool, BitstreamError> {
+        if self.bpos == 0 || self.bpos > 8 {
+            return Err(BitstreamError::IllegalBitPosition(self.bpos));
+        }
+        Ok(self.bpos == 8)
+    }
+
+    pub fn make_byte_aligned(&mut self) -> Result<(), BitstreamError> {
+        let vbit = self.bpos;
+
+        if vbit == 0 || vbit > 8 {
+            return Err(BitstreamError::IllegalBitPosition(vbit));
+        }
+
+        if self.bits_left < 0 {
+            self.bits_left = (self.bits_left - 7) / 8 * 8;
+            return Ok(());
+        }
+
+        if self.bpos != 8 {
+            self.bpos = 8;
+            self.current_pos += 1;
+        }
+
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64;
+        Ok(())
+    }
+
+    pub fn next_bytes(&mut self, bynum: usize) -> Result<Option<&[u8]>, BitstreamError> {
+        if self.bits_left < 0 {
+            self.bits_left -= (bynum * 8) as i64;
+            return Ok(None);
+        }
+
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - (bynum * 8) as i64;
+
+        if !self.is_byte_aligned()? || self.bits_left < 0 || bynum < 1 {
+            return Ok(None);
+        }
+
+        self._i_bpos = 8;
+        self._i_pos = self.current_pos + bynum;
+
+        Ok(Some(&self.pos[self.current_pos..min(self.current_pos + bynum, self.pos.len())]))
+    }
+
+    pub fn read_bytes(&mut self, bynum: usize) -> Result<Option<&[u8]>, BitstreamError> {
+        if self.bits_left < 0 {
+            self.bits_left -= (bynum * 8) as i64;
+            return Ok(None);
+        }
+
+        if !self.is_byte_aligned()? || bynum < 1 {
+            return Ok(None);
+        }
+
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - (bynum * 8) as i64;
+        if self.bits_left < 0 {
+            return Ok(None);
+        }
+
+        let new_pos = self.current_pos + bynum;
+        let slice = &self.pos[self.current_pos..min(new_pos, self.pos.len())];
+        
+        self.bpos = 8;
+        self.current_pos = new_pos;
+        
+        Ok(Some(slice))
+    }
+
+    pub fn read_exp_golomb_unsigned(&mut self) -> Result<u64, BitstreamError> {
+        let mut zeros = 0;
+
+        while self.read_bits(1)? == 0 && self.bits_left >= 0 {
+            zeros += 1;
+        }
+
+        let res = (1u64 << zeros) - 1 + self.read_bits(zeros as u32)?;
+        Ok(res)
+    }
+
+    pub fn read_exp_golomb(&mut self) -> Result<i64, BitstreamError> {
+        let res = self.read_exp_golomb_unsigned()? as i64;
+        Ok((res / 2 + if res % 2 != 0 { 1 } else { 0 }) * if res % 2 != 0 { 1 } else { -1 })
+    }
+
+    pub fn reverse8(data: u8) -> u8 {
+        let mut res = 0u8;
+        for k in 0..8 {
+            res <<= 1;
+            res |= (data & (1 << k)) >> k;
+        }
+        res
+    }
+}
+
+// FFI exports
+#[no_mangle]
+pub extern "C" fn ccxr_init_bitstream(start: *const u8, end: *const u8) -> *mut Bitstream<'static> {
+    if start.is_null() || end.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    unsafe {
+        let len = end.offset_from(start) as usize;
+        let slice = std::slice::from_raw_parts(start, len);
+        match Bitstream::new(slice) {
+            Ok(bs) => Box::into_raw(Box::new(bs)),
+            Err(_) => std::ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_free_bitstream(bs: *mut Bitstream<'static>) {
+    if !bs.is_null() {
+        unsafe {
+            drop(Box::from_raw(bs));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_next_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 {
+    if bs.is_null() {
+        return 0;
+    }
+    unsafe {
+        match (*bs).next_bits(bnum) {
+            Ok(val) => val,
+            Err(_) => 0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_read_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 {
+    if bs.is_null() {
+        return 0;
+    }
+    unsafe {
+        match (*bs).read_bits(bnum) {
+            Ok(val) => val,
+            Err(_) => 0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_skip_bits(bs: *mut Bitstream<'static>, bnum: u32) -> i32 {
+    if bs.is_null() {
+        return 0;
+    }
+    unsafe {
+        match (*bs).skip_bits(bnum) {
+            Ok(true) => 1,
+            Ok(false) => 0,
+            Err(_) => 0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_is_byte_aligned(bs: *const Bitstream<'static>) -> i32 {
+    if bs.is_null() {
+        return 0;
+    }
+    unsafe {
+        match (*bs).is_byte_aligned() {
+            Ok(true) => 1,
+            Ok(false) => 0,
+            Err(_) => 0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_make_byte_aligned(bs: *mut Bitstream<'static>) {
+    if !bs.is_null() {
+        unsafe {
+            let _ = (*bs).make_byte_aligned();
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_next_bytes(bs: *mut Bitstream<'static>, bynum: usize) -> *const u8 {
+    if bs.is_null() {
+        return std::ptr::null();
+    }
+    unsafe {
+        match (*bs).next_bytes(bynum) {
+            Ok(Some(bytes)) => bytes.as_ptr(),
+            _ => std::ptr::null()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_read_bytes(bs: *mut Bitstream<'static>, bynum: usize) -> *const u8 {
+    if bs.is_null() {
+        return std::ptr::null();
+    }
+    unsafe {
+        match (*bs).read_bytes(bynum) {
+            Ok(Some(bytes)) => bytes.as_ptr(),
+            _ => std::ptr::null()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_read_exp_golomb_unsigned(bs: *mut Bitstream<'static>) -> u64 {
+    if bs.is_null() {
+        return 0;
+    }
+    unsafe {
+        match (*bs).read_exp_golomb_unsigned() {
+            Ok(val) => val,
+            Err(_) => 0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_read_exp_golomb(bs: *mut Bitstream<'static>) -> i64 {
+    if bs.is_null() {
+        return 0;
+    }
+    unsafe {
+        match (*bs).read_exp_golomb() {
+            Ok(val) => val,
+            Err(_) => 0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ccxr_reverse8(data: u8) -> u8 {
+    Bitstream::reverse8(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitstream_creation() {
+        let data = vec![0xFF, 0x00];
+        let bs = Bitstream::new(&data);
+        assert!(bs.is_ok());
+    }
+
+    #[test]
+    fn test_read_bits() {
+        let data = vec![0b10101010];
+        let mut bs = Bitstream::new(&data).unwrap();
+        
+        assert_eq!(bs.read_bits(1).unwrap(), 1);
+        assert_eq!(bs.read_bits(1).unwrap(), 0);
+        assert_eq!(bs.read_bits(1).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_byte_alignment() {
+        let data = vec![0xFF];
+        let mut bs = Bitstream::new(&data).unwrap();
+        
+        assert!(bs.is_byte_aligned().unwrap());
+        bs.read_bits(1).unwrap();
+        assert!(!bs.is_byte_aligned().unwrap());
+        bs.make_byte_aligned().unwrap();
+        assert!(bs.is_byte_aligned().unwrap());
+    }
+} 

--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -279,9 +279,7 @@ pub extern "C" fn ccxr_next_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 
     if bs.is_null() {
         return 0;
     }
-    unsafe {
-        (*bs).next_bits(bnum).unwrap_or_default()
-    }
+    unsafe { (*bs).next_bits(bnum).unwrap_or_default() }
 }
 
 #[no_mangle]
@@ -289,9 +287,7 @@ pub extern "C" fn ccxr_read_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 
     if bs.is_null() {
         return 0;
     }
-    unsafe {
-        (*bs).read_bits(bnum).unwrap_or_default()
-    }
+    unsafe { (*bs).read_bits(bnum).unwrap_or_default() }
 }
 
 #[no_mangle]
@@ -362,9 +358,7 @@ pub extern "C" fn ccxr_read_exp_golomb_unsigned(bs: *mut Bitstream<'static>) -> 
     if bs.is_null() {
         return 0;
     }
-    unsafe {
-        (*bs).read_exp_golomb_unsigned().unwrap_or_default()
-    }
+    unsafe { (*bs).read_exp_golomb_unsigned().unwrap_or_default() }
 }
 
 #[no_mangle]
@@ -372,9 +366,7 @@ pub extern "C" fn ccxr_read_exp_golomb(bs: *mut Bitstream<'static>) -> i64 {
     if bs.is_null() {
         return 0;
     }
-    unsafe {
-        (*bs).read_exp_golomb().unwrap_or_default()
-    }
+    unsafe { (*bs).read_exp_golomb().unwrap_or_default() }
 }
 
 #[no_mangle]

--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -2,25 +2,6 @@ use crate::fatal;
 use crate::util::log::ExitCause;
 use thiserror::Error;
 
-/// Trait for converting Rust types to their C counterparts
-pub trait CType<T> {
-    /// Convert the Rust type to its C counterpart
-    ///
-    /// # Safety
-    /// This function is unsafe because it creates raw pointers and assumes the underlying data
-    /// remains valid for the lifetime of the C type. The caller must ensure that:
-    /// - The source data outlives the C type
-    /// - The pointers created are valid and properly aligned
-    /// - The data is not mutably aliased
-    unsafe fn to_ctype(&self) -> T;
-}
-
-/// Trait for converting C types to their Rust counterparts
-pub trait FromC<T> {
-    /// Convert the C type to its Rust counterpart
-    fn from_c(value: T) -> Self;
-}
-
 #[derive(Debug, Error)]
 pub enum BitstreamError {
     #[error("Bitstream has negative length")]

--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -64,7 +64,7 @@ impl<'a> Bitstream<'a> {
         let mut res = 0u64;
         let mut bits_to_read = bnum;
 
-        if vbit < 1 || vbit > 8 {
+        if !(1..=8).contains(&vbit) {
             return Err(BitstreamError::IllegalBitPosition(vbit));
         }
 
@@ -280,10 +280,7 @@ pub extern "C" fn ccxr_next_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 
         return 0;
     }
     unsafe {
-        match (*bs).next_bits(bnum) {
-            Ok(val) => val,
-            Err(_) => 0,
-        }
+        (*bs).next_bits(bnum).unwrap_or_default()
     }
 }
 
@@ -293,10 +290,7 @@ pub extern "C" fn ccxr_read_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 
         return 0;
     }
     unsafe {
-        match (*bs).read_bits(bnum) {
-            Ok(val) => val,
-            Err(_) => 0,
-        }
+        (*bs).read_bits(bnum).unwrap_or_default()
     }
 }
 
@@ -369,10 +363,7 @@ pub extern "C" fn ccxr_read_exp_golomb_unsigned(bs: *mut Bitstream<'static>) -> 
         return 0;
     }
     unsafe {
-        match (*bs).read_exp_golomb_unsigned() {
-            Ok(val) => val,
-            Err(_) => 0,
-        }
+        (*bs).read_exp_golomb_unsigned().unwrap_or_default()
     }
 }
 
@@ -382,10 +373,7 @@ pub extern "C" fn ccxr_read_exp_golomb(bs: *mut Bitstream<'static>) -> i64 {
         return 0;
     }
     unsafe {
-        match (*bs).read_exp_golomb() {
-            Ok(val) => val,
-            Err(_) => 0,
-        }
+        (*bs).read_exp_golomb().unwrap_or_default()
     }
 }
 

--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -48,7 +48,9 @@ impl<'a> Bitstream<'a> {
         }
 
         // Calculate remaining bits
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - bnum as i64;
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
+            + self.bpos as i64
+            - bnum as i64;
         if self.bits_left < 0 {
             return Ok(0);
         }
@@ -72,8 +74,12 @@ impl<'a> Bitstream<'a> {
             }
 
             let current_byte = self.pos[vpos];
-            res |= if (current_byte & (1 << (vbit - 1))) != 0 { 1 } else { 0 };
-            
+            res |= if (current_byte & (1 << (vbit - 1))) != 0 {
+                1
+            } else {
+                0
+            };
+
             vbit -= 1;
             bits_to_read -= 1;
 
@@ -114,7 +120,9 @@ impl<'a> Bitstream<'a> {
             return Ok(false);
         }
 
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - bnum as i64;
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
+            + self.bpos as i64
+            - bnum as i64;
         if self.bits_left < 0 {
             return Ok(false);
         }
@@ -161,7 +169,8 @@ impl<'a> Bitstream<'a> {
             self.current_pos += 1;
         }
 
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64;
+        self.bits_left =
+            (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64;
         Ok(())
     }
 
@@ -171,7 +180,9 @@ impl<'a> Bitstream<'a> {
             return Ok(None);
         }
 
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - (bynum * 8) as i64;
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
+            + self.bpos as i64
+            - (bynum * 8) as i64;
 
         if !self.is_byte_aligned()? || self.bits_left < 0 || bynum < 1 {
             return Ok(None);
@@ -180,7 +191,9 @@ impl<'a> Bitstream<'a> {
         self._i_bpos = 8;
         self._i_pos = self.current_pos + bynum;
 
-        Ok(Some(&self.pos[self.current_pos..min(self.current_pos + bynum, self.pos.len())]))
+        Ok(Some(
+            &self.pos[self.current_pos..min(self.current_pos + bynum, self.pos.len())],
+        ))
     }
 
     pub fn read_bytes(&mut self, bynum: usize) -> Result<Option<&[u8]>, BitstreamError> {
@@ -193,17 +206,19 @@ impl<'a> Bitstream<'a> {
             return Ok(None);
         }
 
-        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8 + self.bpos as i64 - (bynum * 8) as i64;
+        self.bits_left = (self.pos.len() as i64 - self.current_pos as i64 - 1) * 8
+            + self.bpos as i64
+            - (bynum * 8) as i64;
         if self.bits_left < 0 {
             return Ok(None);
         }
 
         let new_pos = self.current_pos + bynum;
         let slice = &self.pos[self.current_pos..min(new_pos, self.pos.len())];
-        
+
         self.bpos = 8;
         self.current_pos = new_pos;
-        
+
         Ok(Some(slice))
     }
 
@@ -245,7 +260,7 @@ pub extern "C" fn ccxr_init_bitstream(start: *const u8, end: *const u8) -> *mut 
         let slice = std::slice::from_raw_parts(start, len);
         match Bitstream::new(slice) {
             Ok(bs) => Box::into_raw(Box::new(bs)),
-            Err(_) => std::ptr::null_mut()
+            Err(_) => std::ptr::null_mut(),
         }
     }
 }
@@ -267,7 +282,7 @@ pub extern "C" fn ccxr_next_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 
     unsafe {
         match (*bs).next_bits(bnum) {
             Ok(val) => val,
-            Err(_) => 0
+            Err(_) => 0,
         }
     }
 }
@@ -280,7 +295,7 @@ pub extern "C" fn ccxr_read_bits(bs: *mut Bitstream<'static>, bnum: u32) -> u64 
     unsafe {
         match (*bs).read_bits(bnum) {
             Ok(val) => val,
-            Err(_) => 0
+            Err(_) => 0,
         }
     }
 }
@@ -294,7 +309,7 @@ pub extern "C" fn ccxr_skip_bits(bs: *mut Bitstream<'static>, bnum: u32) -> i32 
         match (*bs).skip_bits(bnum) {
             Ok(true) => 1,
             Ok(false) => 0,
-            Err(_) => 0
+            Err(_) => 0,
         }
     }
 }
@@ -308,7 +323,7 @@ pub extern "C" fn ccxr_is_byte_aligned(bs: *const Bitstream<'static>) -> i32 {
         match (*bs).is_byte_aligned() {
             Ok(true) => 1,
             Ok(false) => 0,
-            Err(_) => 0
+            Err(_) => 0,
         }
     }
 }
@@ -330,7 +345,7 @@ pub extern "C" fn ccxr_next_bytes(bs: *mut Bitstream<'static>, bynum: usize) -> 
     unsafe {
         match (*bs).next_bytes(bynum) {
             Ok(Some(bytes)) => bytes.as_ptr(),
-            _ => std::ptr::null()
+            _ => std::ptr::null(),
         }
     }
 }
@@ -343,7 +358,7 @@ pub extern "C" fn ccxr_read_bytes(bs: *mut Bitstream<'static>, bynum: usize) -> 
     unsafe {
         match (*bs).read_bytes(bynum) {
             Ok(Some(bytes)) => bytes.as_ptr(),
-            _ => std::ptr::null()
+            _ => std::ptr::null(),
         }
     }
 }
@@ -356,7 +371,7 @@ pub extern "C" fn ccxr_read_exp_golomb_unsigned(bs: *mut Bitstream<'static>) -> 
     unsafe {
         match (*bs).read_exp_golomb_unsigned() {
             Ok(val) => val,
-            Err(_) => 0
+            Err(_) => 0,
         }
     }
 }
@@ -369,7 +384,7 @@ pub extern "C" fn ccxr_read_exp_golomb(bs: *mut Bitstream<'static>) -> i64 {
     unsafe {
         match (*bs).read_exp_golomb() {
             Ok(val) => val,
-            Err(_) => 0
+            Err(_) => 0,
         }
     }
 }
@@ -394,7 +409,7 @@ mod tests {
     fn test_read_bits() {
         let data = vec![0b10101010];
         let mut bs = Bitstream::new(&data).unwrap();
-        
+
         assert_eq!(bs.read_bits(1).unwrap(), 1);
         assert_eq!(bs.read_bits(1).unwrap(), 0);
         assert_eq!(bs.read_bits(1).unwrap(), 1);
@@ -404,11 +419,11 @@ mod tests {
     fn test_byte_alignment() {
         let data = vec![0xFF];
         let mut bs = Bitstream::new(&data).unwrap();
-        
+
         assert!(bs.is_byte_aligned().unwrap());
         bs.read_bits(1).unwrap();
         assert!(!bs.is_byte_aligned().unwrap());
         bs.make_byte_aligned().unwrap();
         assert!(bs.is_byte_aligned().unwrap());
     }
-} 
+}

--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -324,10 +324,6 @@ impl<'a> BitStreamRust<'a> {
     pub fn read_exp_golomb(&mut self) -> Result<i64, BitstreamError> {
         let res = self.read_exp_golomb_unsigned()? as i64;
 
-        // The following function might truncate when res+1 overflows
-        // res = (res+1)/2 * (res % 2 ? 1 : -1);
-        // Use this:
-        // C: res = (res / 2 + (res % 2 ? 1 : 0)) * (res % 2 ? 1 : -1);
         let result =
             (res / 2 + if res % 2 != 0 { 1 } else { 0 }) * if res % 2 != 0 { 1 } else { -1 };
 
@@ -341,9 +337,6 @@ impl<'a> BitStreamRust<'a> {
         if bnum == 0 {
             return Ok(0);
         }
-
-        // C: return (0xFFFFFFFFFFFFFFFFULL << bnum) | res;
-        // Sign extend by filling upper bits with 1s
         let result = (0xFFFFFFFFFFFFFFFFu64 << bnum) | res;
 
         Ok(result as i64)

--- a/src/rust/lib_ccxr/src/common/mod.rs
+++ b/src/rust/lib_ccxr/src/common/mod.rs
@@ -16,8 +16,10 @@
 //! | `cdp_section_type`      | [`CdpSectionType`]         |
 //! | `language[NB_LANGUAGE]` | [`Language`]               |
 
+mod bitstream;
 mod constants;
 mod options;
 
+pub use bitstream::*;
 pub use constants::*;
 pub use options::*;

--- a/src/rust/lib_ccxr/src/teletext.rs
+++ b/src/rust/lib_ccxr/src/teletext.rs
@@ -519,14 +519,11 @@ impl G0Charset {
                     self.g0_charset[0x00][pos] = ch;
                 }
                 if self.verbose_debug {
-                    eprintln!("- Using G0 Latin National Subset ID {} ({})", subset, s);
+                    eprintln!("- Using G0 Latin National Subset ID {subset} ({s})");
                 }
                 self.primary_charset_current = subset;
             } else {
-                eprintln!(
-                    "- G0 Latin National Subset ID {} is not implemented",
-                    subset
-                );
+                eprintln!("- G0 Latin National Subset ID {subset} is not implemented");
             }
         }
     }
@@ -960,9 +957,9 @@ impl<'a> TeletextContext<'a> {
         #[cfg(feature = "debug")]
         {
             for (index, row) in self.page_buffer.text.iter().enumerate().skip(1) {
-                print!("DEUBG[{:02}]: ", index);
+                print!("DEBUG[{index:02}]: ");
                 for c in row {
-                    print!("{:3x} ", c)
+                    print!("{c:3x} ")
                 }
                 println!();
             }
@@ -1068,10 +1065,7 @@ impl<'a> TeletextContext<'a> {
                     let timecode_show_mmss = &timecode_show[3..8];
                     let timecode_hide_mmss = &timecode_hide[3..8];
                     // Note, only MM:SS here as we need to save space in the preview window
-                    eprint!(
-                        "###TIME###{}-{}\n###SUBTITLES###",
-                        timecode_show_mmss, timecode_hide_mmss
-                    );
+                    eprint!("###TIME###{timecode_show_mmss}-{timecode_hide_mmss}\n###SUBTITLES###",);
                     time_reported = true;
                 } else {
                     eprint!("###SUBTITLE###");
@@ -1152,7 +1146,7 @@ impl<'a> TeletextContext<'a> {
                         self.page_buffer_cur.get_or_insert("".into()).push(u);
                         if logger().expect("could not access logger").is_gui_mode() {
                             // For now we just handle the easy stuff
-                            eprint!("{}", u);
+                            eprint!("{u}");
                         }
                     }
                 }
@@ -1271,7 +1265,7 @@ impl<'a> TeletextContext<'a> {
                 let mut thisp = ((m as u32) << 8)
                     | ((decode_hamming_8_4(packet.data[1]).unwrap() as u32) << 4)
                     | (decode_hamming_8_4(packet.data[0]).unwrap() as u32);
-                let t1 = format!("{:x}", thisp); // Example: 1928 -> 788
+                let t1 = format!("{thisp:x}"); // Example: 1928 -> 788
                 thisp = t1.parse().unwrap();
                 if !self.seen_sub_page[thisp as usize] {
                     self.seen_sub_page[thisp as usize] = true;

--- a/src/rust/lib_ccxr/src/time/units.rs
+++ b/src/rust/lib_ccxr/src/time/units.rs
@@ -231,7 +231,7 @@ impl Timestamp {
         let s = millis / 1000 - 3600 * h - 60 * m;
         let u = millis - 3600000 * h - 60000 * m - 1000 * s;
         if h > 24 {
-            println!("{}", h)
+            println!("{h}")
         }
         Ok((h.try_into()?, m as u8, s as u8, u as u16))
     }
@@ -248,7 +248,7 @@ impl Timestamp {
     /// ```
     pub fn write_srt_time(&self, output: &mut String) -> Result<(), TimestampError> {
         let (h, m, s, u) = self.as_hms_millis()?;
-        write!(output, "{:02}:{:02}:{:02},{:03}", h, m, s, u)?;
+        write!(output, "{h:02}:{m:02}:{s:02},{u:03}")?;
         Ok(())
     }
 
@@ -264,7 +264,7 @@ impl Timestamp {
     /// ```
     pub fn write_vtt_time(&self, output: &mut String) -> Result<(), TimestampError> {
         let (h, m, s, u) = self.as_hms_millis()?;
-        write!(output, "{:02}:{:02}:{:02}.{:03}", h, m, s, u)?;
+        write!(output, "{h:02}:{m:02}:{s:02}.{u:03}")?;
         Ok(())
     }
 
@@ -288,7 +288,7 @@ impl Timestamp {
         let sign = if self.millis < 0 { "-" } else { "" };
         let timestamp = if self.millis < 0 { -*self } else { *self };
         let (h, m, s, u) = timestamp.as_hms_millis()?;
-        write!(output, "{}{:02}:{:02}:{:02}{}{:03}", sign, h, m, s, sep, u)?;
+        write!(output, "{sign}{h:02}:{m:02}:{s:02}{sep}{u:03}")?;
         Ok(())
     }
 
@@ -325,12 +325,12 @@ impl Timestamp {
             TimestampFormat::None => Ok(()),
             TimestampFormat::HHMMSS => {
                 let (h, m, s, _) = self.as_hms_millis()?;
-                write!(output, "{:02}:{:02}:{:02}", h, m, s)?;
+                write!(output, "{h:02}:{m:02}:{s:02}")?;
                 Ok(())
             }
             TimestampFormat::Seconds { millis_separator } => {
                 let (sec, millis) = self.as_sec_millis()?;
-                write!(output, "{}{}{:03}", sec, millis_separator, millis)?;
+                write!(output, "{sec}{millis_separator}{millis:03}")?;
                 Ok(())
             }
             TimestampFormat::Date { millis_separator } => {
@@ -404,7 +404,7 @@ impl Timestamp {
         let (h, m, s, _) = self.as_hms_millis()?;
         let frame = (self.millis - 1000 * (s + 60 * (m + 60 * h)) as i64) as f64 * 29.97 / 1000.0;
 
-        write!(result, "{:02}:{:02}:{:02};{:02}", h, m, s, frame)?;
+        write!(result, "{h:02}:{m:02}:{s:02};{frame:02}")?;
 
         Ok(result)
     }

--- a/src/rust/lib_ccxr/src/util/bits.rs
+++ b/src/rust/lib_ccxr/src/util/bits.rs
@@ -229,10 +229,10 @@ mod tests {
 
     #[test]
     fn test_get_parity() {
-        assert_eq!(get_parity(0), false);
-        assert_eq!(get_parity(1), true);
-        assert_eq!(get_parity(128), true);
-        assert_eq!(get_parity(255), false);
+        assert!(!get_parity(0));
+        assert!(get_parity(1));
+        assert!(get_parity(128));
+        assert!(!get_parity(255));
     }
 
     #[test]

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -279,8 +279,8 @@ impl<'a> CCExtractorLogger {
 
     fn print(&self, args: &Arguments<'a>) {
         match &self.target {
-            OutputTarget::Stdout => print!("{}", args),
-            OutputTarget::Stderr => eprint!("{}", args),
+            OutputTarget::Stdout => print!("{args}"),
+            OutputTarget::Stderr => eprint!("{args}"),
             OutputTarget::Quiet => {}
         }
     }
@@ -305,7 +305,7 @@ impl<'a> CCExtractorLogger {
             eprint!("\rError: ")
         }
 
-        eprintln!("{}", args);
+        eprintln!("{args}");
     }
 
     /// Log an informational message. Use [`info!`] instead.
@@ -335,22 +335,19 @@ impl<'a> CCExtractorLogger {
         if self.gui_mode {
             match message_type {
                 GuiXdsMessage::ProgramName(program_name) => {
-                    eprintln!("###XDSPROGRAMNAME#{}", program_name)
+                    eprintln!("###XDSPROGRAMNAME#{program_name}")
                 }
                 GuiXdsMessage::ProgramIdNr {
                     minute,
                     hour,
                     date,
                     month,
-                } => eprintln!(
-                    "###XDSPROGRAMIDENTIFICATIONNUMBER#{}#{}#{}#{}",
-                    minute, hour, date, month
-                ),
+                } => eprintln!("###XDSPROGRAMIDENTIFICATIONNUMBER#{minute}#{hour}#{date}#{month}",),
                 GuiXdsMessage::ProgramDescription { line_num, desc } => {
-                    eprintln!("###XDSPROGRAMDESC#{}#{}", line_num, desc)
+                    eprintln!("###XDSPROGRAMDESC#{line_num}#{desc}")
                 }
                 GuiXdsMessage::CallLetters(current_letters) => {
-                    eprintln!("###XDSNETWORKCALLLETTERS#{}", current_letters)
+                    eprintln!("###XDSNETWORKCALLLETTERS#{current_letters}")
                 }
             }
         }
@@ -380,7 +377,7 @@ impl<'a> CCExtractorLogger {
         for (id, chunk) in chunked_data.enumerate() {
             self.print(&format_args!("{:05} | ", id * 16 + start_idx));
             for x in chunk {
-                self.print(&format_args!("{:02X} ", x));
+                self.print(&format_args!("{x:02X} "));
             }
 
             for _ in 0..(16 - chunk.len()) {

--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -1136,7 +1136,15 @@ impl dtvcc_service_decoder {
         window.is_empty = 0;
 
         // Add symbol to window
-        window.rows[window.pen_row as usize] = Box::into_raw(Box::new(sym));
+        if window.memory_reserved == 1 {
+            unsafe {
+                let ptr: *mut dtvcc_symbol =
+                    window.rows[window.pen_row as usize].add(window.pen_column as usize);
+                *ptr = sym;
+            }
+        } else {
+            return;
+        }
 
         // "Painting" char by pen - attribs
         window.pen_attribs[window.pen_row as usize][window.pen_column as usize] =
@@ -1224,6 +1232,30 @@ extern "C" fn ccxr_flush_decoder(dtvcc: *mut dtvcc_ctx, decoder: *mut dtvcc_serv
 mod test {
     use super::*;
     use crate::utils::get_zero_allocated_obj;
+
+    fn setup_test_decoder_with_memory() -> dtvcc_service_decoder {
+        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
+
+        decoder.current_window = 0;
+        decoder.windows[0].is_defined = 1;
+        decoder.windows[0].row_count = 4;
+        decoder.windows[0].col_count = 4;
+        decoder.windows[0].attribs.print_direction =
+            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+
+        let layout = Layout::array::<dtvcc_symbol>(CCX_DTVCC_MAX_COLUMNS as usize).unwrap();
+        decoder.windows[0].rows[0] = unsafe { alloc(layout) } as *mut dtvcc_symbol;
+        decoder.windows[0].memory_reserved = 1;
+
+        *decoder
+    }
+
+    fn cleanup_test_decoder(decoder: &mut dtvcc_service_decoder) {
+        let layout = Layout::array::<dtvcc_symbol>(CCX_DTVCC_MAX_COLUMNS as usize).unwrap();
+        unsafe {
+            dealloc(decoder.windows[0].rows[0] as *mut u8, layout);
+        }
+    }
 
     // -------------------------- C0 Commands-------------------------
     #[test]
@@ -1378,13 +1410,7 @@ mod test {
 
     #[test]
     fn test_process_p16() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
         let block = [b'a', b'b'] as [c_uchar; 2];
 
         decoder.process_p16(&block);
@@ -1393,10 +1419,12 @@ mod test {
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
             assert_eq!(
-                *decoder.windows[0].rows[0],
+                *decoder.windows[0].rows[0].add(0),
                 dtvcc_symbol::new_16(block[0], block[1])
             );
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     // -------------------------- C1 Commands-------------------------
@@ -1640,14 +1668,7 @@ mod test {
     // -------------------------- G0, G1 and extended Commands-------------------------
     #[test]
     fn test_handle_G0() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
 
         // Case: block[0] == 0x7F
         let block = [0x7F, 0x61];
@@ -1657,7 +1678,7 @@ mod test {
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
             assert_eq!(
-                decoder.windows[0].rows[0].read().sym,
+                decoder.windows[0].rows[0].add(0).read().sym,
                 CCX_DTVCC_MUSICAL_NOTE_CHAR
             );
         }
@@ -1668,20 +1689,15 @@ mod test {
 
         assert_eq!(return_value, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 96);
+            assert_eq!(decoder.windows[0].rows[0].add(1).read().sym, 96);
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     #[test]
     fn test_handle_G1() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
 
         let block = [0x7F, 0x61];
         let return_value = decoder.handle_G1(&block);
@@ -1690,20 +1706,15 @@ mod test {
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 0x7F);
+            assert_eq!(decoder.windows[0].rows[0].add(0).read().sym, 0x7F);
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     #[test]
     fn test_handle_extended_char() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
 
         // 0..=0x1F
         let return_value = decoder.handle_extended_char(&[0x1A, 0x61]);
@@ -1715,7 +1726,7 @@ mod test {
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 0x5);
+            assert_eq!(decoder.windows[0].rows[0].add(0).read().sym, 0x5);
         }
 
         // 0x80..=0x9F
@@ -1728,8 +1739,10 @@ mod test {
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 2);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 0x20);
+            assert_eq!(decoder.windows[0].rows[0].add(1).read().sym, 0x20);
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     #[test]
@@ -1754,13 +1767,20 @@ mod test {
         decoder.windows[0].attribs.print_direction =
             dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
 
+        let layout = Layout::array::<dtvcc_symbol>(CCX_DTVCC_MAX_COLUMNS as usize).unwrap();
+        decoder.windows[0].rows[0] = unsafe { alloc(layout) } as *mut dtvcc_symbol;
+        decoder.windows[0].memory_reserved = 1;
+
         decoder.process_character(sym);
 
         // Check changes
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read(), dtvcc_symbol::new(0x41));
+            assert_eq!(
+                decoder.windows[0].rows[0].add(0).read(),
+                dtvcc_symbol::new(0x41)
+            );
         }
     }
 }

--- a/src/rust/src/decoder/timing.rs
+++ b/src/rust/src/decoder/timing.rs
@@ -45,7 +45,7 @@ pub fn get_time_str(time: LLONG) -> String {
     let mm = time / 1000 / 60 - 60 * hh;
     let ss = time / 1000 - 60 * (mm + 60 * hh);
     let ms = time - 1000 * (ss + 60 * (mm + 60 * hh));
-    format!("{:02}:{:02}:{:02},{:03}", hh, mm, ss, ms)
+    format!("{hh:02}:{mm:02}:{ss:02},{ms:03}")
 }
 
 impl ccx_boundary_time {

--- a/src/rust/src/decoder/tv_screen.rs
+++ b/src/rust/src/decoder/tv_screen.rs
@@ -494,7 +494,7 @@ impl dtvcc_tv_screen {
                         buf.push(' ');
                     }
                     let adjusted_val = adjust_odd_parity(self.chars[row_index][i].sym as u8);
-                    buf = format!("{}{:x}", buf, adjusted_val);
+                    buf = format!("{buf}{adjusted_val:x}");
                     bytes_written += 1;
                 }
                 // add 0x80 padding and form byte pair if the last byte pair is not form
@@ -625,7 +625,7 @@ impl dtvcc_tv_screen {
                 red *= 255 / 3;
                 green *= 255 / 3;
                 blue *= 255 / 3;
-                let font_tag = format!("<font color=\"#{:02x}{:02x}{:02x}\">", red, green, blue);
+                let font_tag = format!("<font color=\"#{red:02x}{green:02x}{blue:02x}\">");
                 buf.extend_from_slice(font_tag.as_bytes());
             }
         }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -27,6 +27,7 @@ use std::os::windows::io::{FromRawHandle, RawHandle};
 
 use args::Args;
 use bindings::*;
+use cfg_if::cfg_if;
 use clap::{error::ErrorKind, Parser};
 use common::{copy_from_rust, CType, CType2};
 use decoder::Dtvcc;
@@ -42,29 +43,48 @@ use std::{
     os::raw::{c_char, c_double, c_int, c_long, c_uint},
 };
 
-#[cfg(test)]
-static mut cb_708: c_int = 0;
-#[cfg(test)]
-static mut cb_field1: c_int = 0;
-#[cfg(test)]
-static mut cb_field2: c_int = 0;
+// Mock data for rust unit tests
+cfg_if! {
+    if #[cfg(test)] {
+        static mut cb_708: c_int = 0;
+        static mut cb_field1: c_int = 0;
+        static mut cb_field2: c_int = 0;
+        static mut current_fps: c_double = 30.0;
+        static mut usercolor_rgb: [c_int; 8] = [0; 8];
+        static mut FILEBUFFERSIZE: c_int = 0;
+        static mut MPEG_CLOCK_FREQ: c_int = 90000;
 
+        static mut frames_since_ref_time: c_int = 0;
+        static mut total_frames_count: c_uint = 0;
+        static mut fts_at_gop_start: c_long = 0;
+        static mut gop_rollover: c_int = 0;
+        static mut pts_big_change: c_uint = 0;
+
+        static mut tlt_config: ccx_s_teletext_config = unsafe { std::mem::zeroed() };
+        static mut ccx_options: ccx_s_options = unsafe { std::mem::zeroed() };
+        static mut gop_time: gop_time_code = unsafe { std::mem::zeroed() };
+        static mut first_gop_time: gop_time_code = unsafe { std::mem::zeroed() };
+        static mut ccx_common_timing_settings: ccx_common_timing_settings_t = unsafe { std::mem::zeroed() };
+        static mut capitalization_list: word_list = unsafe { std::mem::zeroed() };
+        static mut profane: word_list = unsafe { std::mem::zeroed() };
+
+        unsafe extern "C" fn version(_location: *const c_char) {}
+        unsafe extern "C" fn set_binary_mode() {}
+    }
+}
+
+// External C symbols (only when not testing)
 #[cfg(not(test))]
 extern "C" {
     static mut cb_708: c_int;
     static mut cb_field1: c_int;
     static mut cb_field2: c_int;
-}
-
-#[allow(dead_code)]
-extern "C" {
+    static mut current_fps: c_double;
     static mut usercolor_rgb: [c_int; 8];
     static mut FILEBUFFERSIZE: c_int;
     static mut MPEG_CLOCK_FREQ: c_int;
     static mut tlt_config: ccx_s_teletext_config;
     static mut ccx_options: ccx_s_options;
-    static mut pts_big_change: c_uint;
-    static mut current_fps: c_double;
     static mut frames_since_ref_time: c_int;
     static mut total_frames_count: c_uint;
     static mut gop_time: gop_time_code;
@@ -74,6 +94,10 @@ extern "C" {
     static mut ccx_common_timing_settings: ccx_common_timing_settings_t;
     static mut capitalization_list: word_list;
     static mut profane: word_list;
+    static mut pts_big_change: c_uint;
+
+    fn version(location: *const c_char);
+    fn set_binary_mode();
 }
 
 /// Initialize env logger with custom format, using stdout as target
@@ -214,12 +238,6 @@ extern "C" fn ccxr_close_handle(handle: RawHandle) {
         // File will close automatically (due to Drop) once it goes out of scope
         let _file = File::from_raw_handle(handle);
     }
-}
-
-extern "C" {
-    fn version(location: *const c_char);
-    #[allow(dead_code)]
-    fn set_binary_mode();
 }
 
 /// # Safety

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -251,7 +251,7 @@ pub unsafe extern "C" fn ccxr_parse_parameters(argc: c_int, argv: *mut *mut c_ch
             match e.kind() {
                 ErrorKind::DisplayHelp => {
                     // Print the help string
-                    println!("{}", e);
+                    println!("{e}");
                     return ExitCause::WithHelp.exit_code();
                 }
                 ErrorKind::DisplayVersion => {
@@ -260,11 +260,11 @@ pub unsafe extern "C" fn ccxr_parse_parameters(argc: c_int, argv: *mut *mut c_ch
                 }
                 ErrorKind::UnknownArgument => {
                     println!("Unknown Argument");
-                    println!("{}", e);
+                    println!("{e}");
                     return ExitCause::MalformedParameter.exit_code();
                 }
                 _ => {
-                    println!("{}", e);
+                    println!("{e}");
                     return ExitCause::Failure.exit_code();
                 }
             }

--- a/src/rust/src/libccxr_exports/bitstream.rs
+++ b/src/rust/src/libccxr_exports/bitstream.rs
@@ -1,0 +1,948 @@
+use crate::bindings::bitstream;
+use lib_ccxr::common::BitStreamRust;
+use lib_ccxr::info;
+use std::os::raw::{c_int, c_uchar};
+
+/// Copies the state from a Rust `BitStreamRust` to a C `bitstream` struct.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bitstream_ptr`) without null checking
+/// - Assumes `bitstream_ptr` points to a valid, properly initialized and aligned `bitstream` struct
+/// - Assumes the `bitstream` struct has sufficient memory allocated for all fields
+/// - Assumes `rust_bitstream` is properly initialized with valid data
+/// - Performs pointer arithmetic on `rust_bitstream.data` assuming it points to valid memory
+/// - The caller must ensure the `bitstream` struct remains valid for the duration of the operation
+/// - The data referenced by `rust_bitstream.data` must remain valid during the operation
+unsafe fn copy_bitstream_from_rust_to_c(
+    bitstream_ptr: *mut bitstream,
+    rust_bitstream: &BitStreamRust,
+) {
+    // Handle empty slice case
+    if rust_bitstream.data.is_empty() {
+        (*bitstream_ptr).pos = std::ptr::null_mut();
+        (*bitstream_ptr).bpos = 8;
+        (*bitstream_ptr).end = std::ptr::null_mut();
+        (*bitstream_ptr).bitsleft = 0;
+        (*bitstream_ptr).error = c_int::from(rust_bitstream.error);
+        (*bitstream_ptr)._i_pos = std::ptr::null_mut();
+        (*bitstream_ptr)._i_bpos = 0;
+        return;
+    }
+
+    // Get the original pos (which is the base of our slice)
+    let base_ptr = rust_bitstream.data.as_ptr() as *mut c_uchar;
+    let end_ptr = base_ptr.add(rust_bitstream.data.len());
+
+    // Current position should be base + rust pos
+    let current_pos_ptr = base_ptr.add(rust_bitstream.pos);
+
+    // Internal position should be base + _i_pos
+    let i_pos_ptr = if rust_bitstream._i_pos <= rust_bitstream.data.len() {
+        base_ptr.add(rust_bitstream._i_pos)
+    } else {
+        base_ptr
+    };
+
+    (*bitstream_ptr).pos = current_pos_ptr;
+    (*bitstream_ptr).bpos = rust_bitstream.bpos as i32;
+    (*bitstream_ptr).end = end_ptr;
+    (*bitstream_ptr).bitsleft = rust_bitstream.bits_left;
+    (*bitstream_ptr).error = c_int::from(rust_bitstream.error);
+    (*bitstream_ptr)._i_pos = i_pos_ptr;
+    (*bitstream_ptr)._i_bpos = rust_bitstream._i_bpos as i32;
+}
+
+/// Converts a C `bitstream` struct to a Rust `BitStreamRust` with static lifetime.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`value`) without null checking
+/// - Assumes `value` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the `pos` and `end` pointers are either both null or both point to valid memory
+/// - Creates a slice with `'static` lifetime from potentially non-static memory
+/// - Assumes the memory region from `pos` to `end` contains valid, readable data
+/// - Assumes `_i_pos` is either null or points to memory within the valid range
+/// - The caller must ensure the memory referenced by the pointers remains valid for the `'static` lifetime
+/// - Performs pointer arithmetic and offset calculations assuming valid pointer relationships
+unsafe fn copy_bitstream_c_to_rust(value: *mut bitstream) -> BitStreamRust<'static> {
+    // We need to work with the original buffer, not just from current position
+    let mut slice: &[u8] = &[];
+    let mut current_pos_in_slice = 0;
+    let mut i_pos_in_slice = 0;
+
+    if !(*value).pos.is_null() && !(*value).end.is_null() {
+        // Calculate total buffer length from pos to end
+        let total_len = (*value).end.offset_from((*value).pos) as usize;
+
+        if total_len > 0 {
+            // Create slice from current position to end
+            slice = std::slice::from_raw_parts((*value).pos, total_len);
+            // Current position in this slice is 0 (since slice starts from current pos)
+            current_pos_in_slice = 0;
+
+            // Calculate _i_pos relative to the slice start (which is current pos)
+            if !(*value)._i_pos.is_null() {
+                let i_offset = (*value)._i_pos.offset_from((*value).pos);
+                i_pos_in_slice = i_offset.max(0) as usize;
+            }
+        }
+    }
+
+    BitStreamRust {
+        data: slice,
+        pos: current_pos_in_slice,
+        bpos: (*value).bpos as u8,
+        bits_left: (*value).bitsleft,
+        error: (*value).error != 0,
+        _i_pos: i_pos_in_slice,
+        _i_bpos: (*value)._i_bpos as u8,
+    }
+}
+/// Updates only the internal state of a C bitstream without modifying current position pointers.
+/// Used by functions like `ccxr_next_bits` that peek at data without advancing the main position.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bitstream_ptr`) without null checking
+/// - Assumes `bitstream_ptr` points to a valid, properly initialized `bitstream` struct
+/// - Assumes `rust_bitstream` is properly initialized with valid data
+/// - Performs pointer arithmetic assuming valid memory layout
+/// - The caller must ensure the `bitstream` struct remains valid during the operation
+unsafe fn copy_internal_state_from_rust_to_c(
+    bitstream_ptr: *mut bitstream,
+    rust_bitstream: &BitStreamRust,
+) {
+    // Only update internal positions and bits_left, NOT current position
+    (*bitstream_ptr).bitsleft = rust_bitstream.bits_left;
+    (*bitstream_ptr).error = c_int::from(rust_bitstream.error);
+    (*bitstream_ptr)._i_bpos = rust_bitstream._i_bpos as i32;
+
+    // Handle _i_pos
+    if rust_bitstream.data.is_empty() {
+        (*bitstream_ptr)._i_pos = std::ptr::null_mut();
+    } else {
+        let base_ptr = rust_bitstream.data.as_ptr() as *mut c_uchar;
+        let i_pos_ptr = if rust_bitstream._i_pos <= rust_bitstream.data.len() {
+            base_ptr.add(rust_bitstream._i_pos)
+        } else {
+            base_ptr // Fallback to start if out of bounds
+        };
+        (*bitstream_ptr)._i_pos = i_pos_ptr;
+    }
+}
+
+/// Free a bitstream created by Rust allocation functions.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer without null checking (though it does check for null)
+/// - Assumes the pointer was allocated by Rust and is owned by a `Box`
+/// - Assumes no other references to the `BitStreamRust` exist when this is called
+/// - The pointer must not be used after this function returns
+/// - This function must only be called once per allocated bitstream
+/// - Double-free will occur if called multiple times with the same pointer
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_free_bitstream(bs: *mut BitStreamRust<'static>) {
+    if !bs.is_null() {
+        drop(Box::from_raw(bs));
+    }
+}
+
+/// Read bits from a bitstream without advancing the position (peek operation).
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers (`pos`, `end`, `_i_pos`) point to valid, readable memory
+/// - Assumes the memory region contains valid data and has sufficient bits available
+/// - Modifies the internal state of the bitstream struct
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+/// - The underlying data must not be modified during the operation
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_next_bits(bs: *mut bitstream, bnum: u32) -> u64 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    let val = match rust_bs.next_bits(bnum) {
+        Ok(val) => val,
+        Err(_) => return 0,
+    };
+    // Only copy back internal state, NOT current position
+    copy_internal_state_from_rust_to_c(bs, &rust_bs);
+    val
+}
+
+/// Read bits from a bitstream and advance the position.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Assumes the memory region contains sufficient readable bits for the requested operation
+/// - Modifies the bitstream state including position pointers
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+/// - The underlying data must not be modified during the operation
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_read_bits(bs: *mut bitstream, bnum: u32) -> u64 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    let val = match rust_bs.read_bits(bnum) {
+        Ok(val) => val,
+        Err(_) => return 0,
+    };
+    copy_bitstream_from_rust_to_c(bs, &rust_bs);
+    val
+}
+
+/// Skip a number of bits in the bitstream.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid memory
+/// - Assumes the bitstream contains at least the requested number of bits to skip
+/// - Modifies the bitstream state including position pointers
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_skip_bits(bs: *mut bitstream, bnum: u32) -> i32 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    let val = match rust_bs.skip_bits(bnum) {
+        Ok(val) => val,
+        Err(_) => return 0,
+    };
+    copy_bitstream_from_rust_to_c(bs, &rust_bs);
+    if val {
+        1
+    } else {
+        0
+    }
+}
+
+/// Check if the bitstream is byte aligned.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid memory
+/// - The caller must ensure the bitstream remains valid during the operation
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_is_byte_aligned(bs: *mut bitstream) -> i32 {
+    let rust_bs = copy_bitstream_c_to_rust(bs);
+    match rust_bs.is_byte_aligned() {
+        Ok(val) => {
+            if val {
+                1
+            } else {
+                0
+            }
+        }
+        Err(_) => 0,
+    }
+}
+
+/// Align the bitstream to the next byte boundary.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Modifies the bitstream state including position pointers
+/// - Assumes the bitstream has sufficient bits available to reach the next byte boundary
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_make_byte_aligned(bs: *mut bitstream) {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    if rust_bs.make_byte_aligned().is_ok() {
+        copy_bitstream_from_rust_to_c(bs, &rust_bs);
+    } else {
+        info!("Bitstream : Failed to make bitstream byte aligned");
+    }
+}
+
+/// Get a pointer to the next bytes in the bitstream without advancing the position.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Returns a raw pointer that must not outlive the bitstream or be used after bitstream modification
+/// - Assumes the bitstream is byte-aligned before calling this function
+/// - Assumes the bitstream contains at least `bynum` readable bytes
+/// - Modifies the internal state of the bitstream
+/// - The returned pointer points to read-only memory that must not be modified
+/// - The caller must ensure the bitstream and its data remain valid while using the returned pointer
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_next_bytes(bs: *mut bitstream, bynum: usize) -> *const u8 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    match rust_bs.next_bytes(bynum) {
+        Ok(slice) => {
+            // Copy back internal state only (like next_bits does)
+            copy_internal_state_from_rust_to_c(bs, &rust_bs);
+            slice.as_ptr()
+        }
+        Err(_) => std::ptr::null(),
+    }
+}
+
+/// Read bytes from the bitstream and advance the position.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Returns a raw pointer that must not outlive the bitstream or be used after bitstream modification
+/// - Assumes the bitstream is byte-aligned before calling this function
+/// - Assumes the bitstream contains at least `bynum` readable bytes
+/// - Modifies the bitstream state including position pointers
+/// - The returned pointer points to read-only memory that must not be modified
+/// - The caller must ensure the bitstream and its data remain valid while using the returned pointer
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_read_bytes(bs: *mut bitstream, bynum: usize) -> *const u8 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    match rust_bs.read_bytes(bynum) {
+        Ok(slice) => {
+            copy_bitstream_from_rust_to_c(bs, &rust_bs);
+            slice.as_ptr()
+        }
+        Err(_) => std::ptr::null(),
+    }
+}
+/// Read a multi-byte number from the bitstream with optional position advancement.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Assumes the bitstream contains at least `bytes` readable bytes
+/// - Modifies the bitstream state including position pointers
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+/// - The `bytes` parameter should be reasonable (typically 1-8) to avoid potential overflow
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_bitstream_get_num(
+    bs: *mut bitstream,
+    bytes: usize,
+    advance: i32,
+) -> u64 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    let result = rust_bs.bitstream_get_num(bytes, advance != 0).unwrap_or(0);
+    copy_bitstream_from_rust_to_c(bs, &rust_bs);
+    result
+}
+
+/// Read an unsigned Exp-Golomb code from the bitstream.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Assumes the bitstream contains a valid Exp-Golomb encoded value
+/// - Assumes the bitstream has sufficient bits to read the complete encoded value
+/// - Modifies the bitstream state including position pointers
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_read_exp_golomb_unsigned(bs: *mut bitstream) -> u64 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    let result = rust_bs.read_exp_golomb_unsigned().unwrap_or(0);
+    copy_bitstream_from_rust_to_c(bs, &rust_bs);
+    result
+}
+
+/// Read a signed Exp-Golomb code from the bitstream.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Assumes the bitstream contains a valid signed Exp-Golomb encoded value
+/// - Assumes the bitstream has sufficient bits to read the complete encoded value
+/// - Modifies the bitstream state including position pointers
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_read_exp_golomb(bs: *mut bitstream) -> i64 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    let result = rust_bs.read_exp_golomb().unwrap_or(0);
+    copy_bitstream_from_rust_to_c(bs, &rust_bs);
+    result
+}
+/// Read a signed integer value from the specified number of bits.
+///
+/// # Safety
+/// This function is unsafe because it:
+/// - Dereferences a raw pointer (`bs`) without null checking
+/// - Assumes `bs` points to a valid, properly initialized `bitstream` struct
+/// - Assumes the bitstream's data pointers point to valid, readable memory
+/// - Assumes the bitstream contains at least `bnum` readable bits
+/// - Modifies the bitstream state including position pointers
+/// - The caller must ensure the bitstream remains valid and is not accessed concurrently
+/// - The `bnum` parameter should be reasonable (typically 1-64) for integer representation
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_read_int(bs: *mut bitstream, bnum: u32) -> i64 {
+    let mut rust_bs = copy_bitstream_c_to_rust(bs);
+    let result = rust_bs.read_int(bnum).unwrap_or(0);
+    copy_bitstream_from_rust_to_c(bs, &rust_bs);
+    result
+}
+
+/// Reverse the bits in a byte (bit 0 becomes bit 7, etc.).
+///
+/// # Safety
+/// This function is marked unsafe only because it's part of the FFI interface.
+/// It does not perform any unsafe operations internally and is safe to call with any `u8` value.
+/// The safety requirements exist only due to the C calling convention.
+#[no_mangle]
+pub unsafe extern "C" fn ccxr_reverse8(data: u8) -> u8 {
+    BitStreamRust::reverse8(data)
+}
+
+mod tests {
+    // FFI binding tests
+    #[test]
+    fn test_ffi_next_bits() {
+        let data = vec![0b10101010];
+        let mut c_bs = crate::bindings::bitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(unsafe { super::ccxr_next_bits(&mut c_bs, 1) }, 1);
+    }
+
+    #[test]
+    fn test_ffi_read_bits() {
+        let data = vec![0b10101010];
+        let mut c_bs = crate::bindings::bitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(unsafe { super::ccxr_read_bits(&mut c_bs, 3) }, 0b101);
+    }
+
+    #[test]
+    fn test_ffi_byte_alignment() {
+        let data = vec![0xFF];
+        let mut c_bs = crate::bindings::bitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(
+            unsafe { super::ccxr_is_byte_aligned(&mut c_bs as *mut crate::bindings::bitstream) },
+            1
+        );
+        unsafe { super::ccxr_read_bits(&mut c_bs, 1) };
+        assert_eq!(
+            unsafe { super::ccxr_is_byte_aligned(&mut c_bs as *mut crate::bindings::bitstream) },
+            0
+        );
+    }
+
+    #[test]
+    fn test_ffi_read_bytes() {
+        static DATA: [u8; 3] = [0xAA, 0xBB, 0xCC];
+        let mut c_bs = crate::bindings::bitstream {
+            pos: DATA.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { DATA.as_ptr().add(DATA.len()) } as *mut u8,
+            bitsleft: (DATA.len() as i64) * 8,
+            error: 0,
+            _i_pos: DATA.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        unsafe {
+            let ptr = super::ccxr_read_bytes(&mut c_bs, 2);
+            assert!(!ptr.is_null());
+            let b1 = *ptr;
+            let b2 = *ptr.add(1);
+            assert_eq!([b1, b2], [0xAA, 0xBB]);
+        }
+    }
+
+    #[test]
+    fn test_ffi_exp_golomb() {
+        let data = vec![0b10000000];
+        let data_ptr = data.as_ptr();
+        let mut c_bs = crate::bindings::bitstream {
+            pos: data_ptr as *mut u8,
+            bpos: 8,
+            end: unsafe { data_ptr.add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data_ptr as *mut u8,
+            _i_bpos: 8,
+        };
+
+        assert_eq!(unsafe { super::ccxr_read_exp_golomb_unsigned(&mut c_bs) }, 0);
+        drop(data);
+    }
+
+    #[test]
+    fn test_ffi_reverse8() {
+        assert_eq!(unsafe { super::ccxr_reverse8(0b10101010) }, 0b01010101);
+    }
+
+    #[test]
+    fn test_ffi_state_updates() {
+        let data = vec![0xAA, 0xBB];
+        let mut c_bs = crate::bindings::bitstream {
+            pos: data.as_ptr() as *mut u8,
+            bpos: 8,
+            end: unsafe { data.as_ptr().add(data.len()) } as *mut u8,
+            bitsleft: (data.len() as i64) * 8,
+            error: 0,
+            _i_pos: data.as_ptr() as *mut u8,
+            _i_bpos: 8,
+        };
+
+        unsafe { super::ccxr_read_bits(&mut c_bs, 4) };
+        assert_eq!(c_bs.bpos, 4);
+    }
+}
+#[cfg(test)]
+mod bitstream_copying_tests {
+    use super::*;
+    use std::ptr;
+
+    // Test helper function to create a test buffer
+    fn create_test_buffer(size: usize) -> Vec<u8> {
+        (0..size).map(|i| (i % 256) as u8).collect()
+    }
+
+    // Test helper to verify pointer arithmetic safety
+    unsafe fn verify_pointer_bounds(c_stream: &bitstream) -> bool {
+        !c_stream.pos.is_null() && !c_stream.end.is_null() && c_stream.pos <= c_stream.end
+    }
+
+    #[test]
+    fn test_rust_to_c_basic_conversion() {
+        let buffer = create_test_buffer(100);
+        let rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 3,
+            bits_left: 789,
+            error: false,
+            _i_pos: 10,
+            _i_bpos: 5,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let c_stream = &*c_s;
+            // Verify basic field conversions
+            assert_eq!(c_stream.bpos, 3);
+            assert_eq!(c_stream.bitsleft, 789);
+            assert_eq!(c_stream.error, 0);
+            assert_eq!(c_stream._i_bpos, 5);
+
+            // Verify pointer arithmetic
+            assert!(verify_pointer_bounds(&c_stream));
+            assert_eq!(c_stream.end.offset_from(c_stream.pos), 100);
+            assert_eq!(c_stream._i_pos.offset_from(c_stream.pos), 10);
+
+            // Verify data integrity
+            let reconstructed_slice = std::slice::from_raw_parts(c_stream.pos, 100);
+            assert_eq!(reconstructed_slice, &buffer[..]);
+        }
+    }
+
+    #[test]
+    fn test_c_to_rust_basic_conversion() {
+        let mut buffer = create_test_buffer(50);
+        let buffer_ptr = buffer.as_mut_ptr();
+
+        unsafe {
+            let mut c_stream = bitstream {
+                pos: buffer_ptr,
+                bpos: 7,
+                end: buffer_ptr.add(50),
+                bitsleft: 400,
+                error: 1,
+                _i_pos: buffer_ptr.add(15),
+                _i_bpos: 2,
+            };
+
+            let rust_stream = copy_bitstream_c_to_rust(&mut c_stream as *mut bitstream);
+
+            // Verify basic field conversions
+            assert_eq!(rust_stream.bpos, 7);
+            assert_eq!(rust_stream.bits_left, 400);
+            assert_eq!(rust_stream.error, true);
+            assert_eq!(rust_stream._i_pos, 15);
+            assert_eq!(rust_stream._i_bpos, 2);
+
+            // Verify slice reconstruction
+            assert_eq!(rust_stream.data.len(), 50);
+            assert_eq!(rust_stream.data, &buffer[..]);
+        }
+    }
+
+    #[test]
+    fn test_round_trip_conversion() {
+        let buffer = create_test_buffer(75);
+        let original = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 4,
+            bits_left: 600,
+            error: true,
+            _i_pos: 25,
+            _i_bpos: 1,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &original);
+            let reconstructed = copy_bitstream_c_to_rust(c_s);
+
+            // Verify all fields match
+            assert_eq!(reconstructed.bpos, original.bpos);
+            assert_eq!(reconstructed.bits_left, original.bits_left);
+            assert_eq!(reconstructed.error, original.error);
+            assert_eq!(reconstructed._i_pos, original._i_pos);
+            assert_eq!(reconstructed._i_bpos, original._i_bpos);
+            assert_eq!(reconstructed.data, original.data);
+        }
+    }
+
+    #[test]
+    fn test_empty_buffer() {
+        let buffer: &[u8] = &[];
+        let rust_stream = BitStreamRust {
+            data: buffer,
+            pos: 0,
+            bpos: 0,
+            bits_left: 0,
+            error: false,
+            _i_pos: 0,
+            _i_bpos: 0,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let c_stream = &mut *c_s;
+
+            // Verify empty buffer handling
+            assert_eq!(c_stream.end.offset_from(c_stream.pos), 0);
+            assert_eq!(c_stream._i_pos.offset_from(c_stream.pos), 0);
+
+            let reconstructed = copy_bitstream_c_to_rust(c_s);
+            assert_eq!(reconstructed.data.len(), 0);
+            assert_eq!(reconstructed._i_pos, 0);
+        }
+    }
+
+    #[test]
+    fn test_single_byte_buffer() {
+        let buffer = vec![0x42u8];
+        let rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 7,
+            bits_left: 1,
+            error: false,
+            _i_pos: 0,
+            _i_bpos: 3,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let c_stream = &mut *c_s;
+            assert_eq!(c_stream.end.offset_from(c_stream.pos), 1);
+
+            let reconstructed = copy_bitstream_c_to_rust(c_s);
+            assert_eq!(reconstructed.data.len(), 1);
+            assert_eq!(reconstructed.data[0], 0x42);
+        }
+    }
+
+    #[test]
+    fn test_large_buffer() {
+        let buffer = create_test_buffer(10000);
+        let rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 2,
+            bits_left: 80000,
+            error: false,
+            _i_pos: 5000,
+            _i_bpos: 6,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let c_stream = &mut *c_s;
+            assert_eq!(c_stream.end.offset_from(c_stream.pos), 10000);
+            assert_eq!(c_stream._i_pos.offset_from(c_stream.pos), 5000);
+
+            let reconstructed = copy_bitstream_c_to_rust(c_s);
+            assert_eq!(reconstructed.data.len(), 10000);
+            assert_eq!(reconstructed._i_pos, 5000);
+        }
+    }
+
+    #[test]
+    fn test_boundary_values() {
+        let buffer = create_test_buffer(256);
+
+        // Test with maximum values
+        let rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 7, // Max value for 3 bits
+            bits_left: i64::MAX,
+            error: true,
+            _i_pos: 255, // Last valid index
+            _i_bpos: 7,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let reconstructed = copy_bitstream_c_to_rust(c_s);
+
+            assert_eq!(reconstructed.bpos, 7);
+            assert_eq!(reconstructed.bits_left, i64::MAX);
+            assert_eq!(reconstructed.error, true);
+            assert_eq!(reconstructed._i_pos, 255);
+            assert_eq!(reconstructed._i_bpos, 7);
+        }
+    }
+
+    #[test]
+    fn test_negative_values() {
+        let buffer = create_test_buffer(50);
+        let rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 0,
+            bits_left: -100, // Negative bits_left
+            error: false,    // Negative error code
+            _i_pos: 0,
+            _i_bpos: 0,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let reconstructed = copy_bitstream_c_to_rust(c_s);
+
+            assert_eq!(reconstructed.bits_left, -100);
+            assert_eq!(reconstructed.error, false);
+        }
+    }
+
+    #[test]
+    fn test_null_i_pos_handling() {
+        let mut buffer = create_test_buffer(30);
+        let buffer_ptr = buffer.as_mut_ptr();
+
+        unsafe {
+            let mut c_stream = bitstream {
+                pos: buffer_ptr,
+                bpos: 0,
+                end: buffer_ptr.add(30),
+                bitsleft: 240,
+                error: 0,
+                _i_pos: ptr::null_mut(), // Null _i_pos
+                _i_bpos: 0,
+            };
+
+            let rust_stream = copy_bitstream_c_to_rust(&mut c_stream as *mut bitstream);
+
+            // Should default to 0 when _i_pos is null
+            assert_eq!(rust_stream._i_pos, 0);
+        }
+    }
+
+    #[test]
+    fn test_different_buffer_positions() {
+        let buffer = create_test_buffer(100);
+
+        // Test different _i_pos values
+        for i_pos in [0, 1, 50, 99] {
+            let rust_stream = BitStreamRust {
+                data: &buffer,
+                pos: 0,
+                bpos: 0,
+                bits_left: 800,
+                error: false,
+                _i_pos: i_pos,
+                _i_bpos: 0,
+            };
+
+            unsafe {
+                let c_s = Box::into_raw(Box::new(bitstream::default()));
+                copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+                let c_stream = &mut *c_s;
+                assert_eq!(c_stream._i_pos.offset_from(c_stream.pos), i_pos as isize);
+
+                let reconstructed = copy_bitstream_c_to_rust(c_s);
+                assert_eq!(reconstructed._i_pos, i_pos);
+            }
+        }
+    }
+
+    #[test]
+    fn test_data_integrity_after_conversion() {
+        // Create a buffer with specific pattern
+        let mut buffer = Vec::new();
+        for i in 0..256 {
+            buffer.push(i as u8);
+        }
+
+        let rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 3,
+            bits_left: 2048,
+            error: false,
+            _i_pos: 128,
+            _i_bpos: 4,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let c_stream = &mut *c_s;
+
+            // Verify we can read the data correctly through C pointers
+            for i in 0..256 {
+                let byte_val = *c_stream.pos.add(i);
+                assert_eq!(byte_val, i as u8);
+            }
+
+            // Verify internal position pointer
+            let internal_byte = *c_stream._i_pos;
+            assert_eq!(internal_byte, 128);
+
+            let reconstructed = copy_bitstream_c_to_rust(c_s);
+            assert_eq!(reconstructed.data.len(), 256);
+            for (i, &byte) in reconstructed.data.iter().enumerate() {
+                assert_eq!(byte, i as u8);
+            }
+        }
+    }
+
+    #[test]
+    fn test_multiple_conversions() {
+        let buffer = create_test_buffer(64);
+        let mut rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 1,
+            bits_left: 512,
+            error: false,
+            _i_pos: 32,
+            _i_bpos: 2,
+        };
+
+        // Test multiple round-trip conversions
+        for _ in 0..5 {
+            rust_stream.error = true;
+
+            unsafe {
+                let c_s = Box::into_raw(Box::new(bitstream::default()));
+                copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+                let new_rust_stream = copy_bitstream_c_to_rust(c_s);
+
+                assert_eq!(new_rust_stream.error, true);
+                assert_eq!(new_rust_stream.data.len(), 64);
+                assert_eq!(new_rust_stream._i_pos, 32);
+
+                rust_stream = new_rust_stream;
+            }
+        }
+    }
+
+    #[test]
+    fn test_bit_position_values() {
+        let buffer = create_test_buffer(10);
+
+        // Test all valid bit positions (0-7)
+        for bpos in 0..8 {
+            let rust_stream = BitStreamRust {
+                data: &buffer,
+                pos: 0,
+                bpos: bpos as u8,
+                bits_left: 80,
+                error: false,
+                _i_pos: 5,
+                _i_bpos: (7 - bpos) as u8,
+            };
+
+            unsafe {
+                let c_s = Box::into_raw(Box::new(bitstream::default()));
+                copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+                let c_stream = &mut *c_s;
+                assert_eq!(c_stream.bpos, bpos);
+                assert_eq!(c_stream._i_bpos, 7 - bpos);
+
+                let reconstructed = copy_bitstream_c_to_rust(c_s);
+                assert_eq!(reconstructed.bpos, bpos as u8);
+                assert_eq!(reconstructed._i_bpos, (7 - bpos) as u8);
+            }
+        }
+    }
+
+    #[test]
+    fn test_memory_safety() {
+        let buffer = create_test_buffer(1000);
+        let rust_stream = BitStreamRust {
+            data: &buffer,
+            pos: 0,
+            bpos: 0,
+            bits_left: 8000,
+            error: false,
+            _i_pos: 500,
+            _i_bpos: 0,
+        };
+
+        unsafe {
+            let c_s = Box::into_raw(Box::new(bitstream::default()));
+            copy_bitstream_from_rust_to_c(c_s, &rust_stream);
+            let c_stream = &mut *c_s;
+
+            // Verify all pointers are within bounds
+            assert!(verify_pointer_bounds(&c_stream));
+
+            // Verify we can safely access the boundaries
+            let first_byte = *c_stream.pos;
+            let last_byte = *c_stream.end.sub(1);
+            let internal_byte = *c_stream._i_pos;
+
+            // These should not panic and should match our buffer
+            assert_eq!(first_byte, 0);
+            assert_eq!(last_byte, (999 % 256) as u8);
+            assert_eq!(internal_byte, (500 % 256) as u8);
+        }
+    }
+}

--- a/src/rust/src/libccxr_exports/bitstream.rs
+++ b/src/rust/src/libccxr_exports/bitstream.rs
@@ -496,7 +496,10 @@ mod tests {
             _i_bpos: 8,
         };
 
-        assert_eq!(unsafe { super::ccxr_read_exp_golomb_unsigned(&mut c_bs) }, 0);
+        assert_eq!(
+            unsafe { super::ccxr_read_exp_golomb_unsigned(&mut c_bs) },
+            0
+        );
         drop(data);
     }
 

--- a/src/rust/src/libccxr_exports/mod.rs
+++ b/src/rust/src/libccxr_exports/mod.rs
@@ -1,6 +1,8 @@
 //! Provides C-FFI functions that are direct equivalent of functions available in C.
 
+pub mod bitstream;
 pub mod time;
+
 use crate::ccx_options;
 use lib_ccxr::util::log::*;
 use lib_ccxr::util::{bits::*, levenshtein::*};

--- a/src/rust/src/libccxr_exports/time.rs
+++ b/src/rust/src/libccxr_exports/time.rs
@@ -6,7 +6,7 @@ use std::ffi::{c_char, c_int, c_long, CStr};
 use crate::{
     bindings::*, cb_708, cb_field1, cb_field2, ccx_common_timing_settings as timing_settings,
     current_fps, first_gop_time, frames_since_ref_time, fts_at_gop_start, gop_rollover, gop_time,
-    pts_big_change, total_frames_count,
+    pts_big_change, total_frames_count, MPEG_CLOCK_FREQ,
 };
 
 use lib_ccxr::common::FrameType;
@@ -279,6 +279,7 @@ unsafe fn apply_timing_info() {
     timing_info.timing_settings.disable_sync_check = timing_settings.disable_sync_check != 0;
     timing_info.timing_settings.no_sync = timing_settings.no_sync != 0;
     timing_info.timing_settings.is_elementary_stream = timing_settings.is_elementary_stream != 0;
+    timing_info.mpeg_clock_freq = MPEG_CLOCK_FREQ.into();
 }
 
 /// Write from [`GLOBAL_TIMING_INFO`] to the equivalent static variables in C.

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -24,13 +24,7 @@ use time::OffsetDateTime;
 use crate::args::CCXCodec;
 use crate::args::{self, InFormat};
 
-cfg_if! {
-    if #[cfg(test)] {
-        use crate::parser::tests::{set_binary_mode, MPEG_CLOCK_FREQ, usercolor_rgb, FILEBUFFERSIZE};
-    } else {
-        use crate::{set_binary_mode, MPEG_CLOCK_FREQ, usercolor_rgb, FILEBUFFERSIZE};
-    }
-}
+use crate::{set_binary_mode, usercolor_rgb, FILEBUFFERSIZE, MPEG_CLOCK_FREQ};
 
 cfg_if! {
     if #[cfg(windows)] {
@@ -1684,9 +1678,6 @@ pub mod tests {
 
     #[no_mangle]
     pub unsafe extern "C" fn set_binary_mode() {}
-    pub static mut MPEG_CLOCK_FREQ: u64 = 0;
-    pub static mut FILEBUFFERSIZE: i32 = 0;
-    pub static mut usercolor_rgb: [i32; 8] = [0; 8];
 
     fn parse_args(args: &[&str]) -> (Options, TeletextConfig) {
         let mut common_args = vec!["./ccextractor", "input_file"];

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -121,8 +121,7 @@ fn process_word_file(filename: &str, list: &mut Vec<String>) -> Result<(), std::
         let new_len = line.trim().len();
         if new_len > CCX_DECODER_608_SCREEN_WIDTH {
             println!(
-                "Word in line {} too long, max = {} characters.",
-                num, CCX_DECODER_608_SCREEN_WIDTH
+                "Word in line {num} too long, max = {CCX_DECODER_608_SCREEN_WIDTH} characters."
             );
             continue;
         }
@@ -1325,7 +1324,7 @@ impl OptionsExt for Options {
                 }
 
                 if !self.transcript_settings.is_final {
-                    let chars = format!("{}", customtxt).chars().collect::<Vec<char>>();
+                    let chars = format!("{customtxt}").chars().collect::<Vec<char>>();
                     self.transcript_settings.show_start_time = chars[0] == '1';
                     self.transcript_settings.show_end_time = chars[1] == '1';
                     self.transcript_settings.show_mode = chars[2] == '1';

--- a/src/rust/wrapper.h
+++ b/src/rust/wrapper.h
@@ -11,3 +11,4 @@
 #include "../lib_ccx/hardsubx.h"
 #include "../lib_ccx/utility.h"
 #include "../lib_ccx/ccx_encoders_helpers.h"
+#include "../lib_ccx/cc_bitstream.h"


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
