### PR TITLE
Bitstream: Removed redundant CType

### DIFF
--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -2,25 +2,6 @@ use crate::fatal;
 use crate::util::log::ExitCause;
 use thiserror::Error;
 
-/// Trait for converting Rust types to their C counterparts
-pub trait CType<T> {
-    /// Convert the Rust type to its C counterpart
-    ///
-    /// # Safety
-    /// This function is unsafe because it creates raw pointers and assumes the underlying data
-    /// remains valid for the lifetime of the C type. The caller must ensure that:
-    /// - The source data outlives the C type
-    /// - The pointers created are valid and properly aligned
-    /// - The data is not mutably aliased
-    unsafe fn to_ctype(&self) -> T;
-}
-
-/// Trait for converting C types to their Rust counterparts
-pub trait FromC<T> {
-    /// Convert the C type to its Rust counterpart
-    fn from_c(value: T) -> Self;
-}
-
 #[derive(Debug, Error)]
 pub enum BitstreamError {
     #[error("Bitstream has negative length")]


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
