### PR TITLE
bitstream: recommended changes for is_byte_aligned

### DIFF
--- a/src/rust/lib_ccxr/src/common/bitstream.rs
+++ b/src/rust/lib_ccxr/src/common/bitstream.rs
@@ -182,11 +182,7 @@ impl<'a> BitStreamRust<'a> {
         if vbit == 0 || vbit > 8 {
             fatal!(cause = ExitCause::Bug; "In is_byte_aligned: Illegal bit position value {}!", vbit);
         }
-        if vbit == 8 {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        Ok(vbit == 8)
     }
 
     /// Align to next byte boundary (commit state).


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
